### PR TITLE
Update webgltexture-loader-expo

### DIFF
--- a/packages/webgltexture-loader-expo/src/DeprecatedExpoGLObjectTextureLoader.js
+++ b/packages/webgltexture-loader-expo/src/DeprecatedExpoGLObjectTextureLoader.js
@@ -4,7 +4,6 @@ import {
   WebGLTextureLoaderAsyncHashCache
 } from "webgltexture-loader";
 import { NativeModules } from "react-native";
-import Expo from "expo";
 
 const neverEnding = new Promise(() => {});
 

--- a/packages/webgltexture-loader-expo/src/ExpoCameraTextureLoader.js
+++ b/packages/webgltexture-loader-expo/src/ExpoCameraTextureLoader.js
@@ -4,7 +4,7 @@ import {
   WebGLTextureLoaderAsyncHashCache
 } from "webgltexture-loader";
 import { NativeModules, findNodeHandle } from "react-native";
-import Expo, { Camera } from "expo";
+import { Camera } from "expo";
 
 const neverEnding = new Promise(() => {});
 

--- a/packages/webgltexture-loader-expo/src/ExpoModuleTextureLoader.js
+++ b/packages/webgltexture-loader-expo/src/ExpoModuleTextureLoader.js
@@ -69,7 +69,8 @@ export const loadAsset = (module: number | { uri: string }): Promise<AssetType> 
     : module.uri.startsWith("file:") ||
       module.uri.startsWith("data:") ||
       module.uri.startsWith("asset:") || // All local paths in Android Expo standalone app
-      module.uri.startsWith("assets-library:") || // CameraRoll.getPhotos
+      module.uri.startsWith("assets-library:") || // CameraRoll.getPhotos iOS
+      module.uri.startsWith("content:") || // CameraRoll.getPhotos Android
       module.uri.startsWith("/") // Expo.takeSnapshotAsync in DEV in Expo 31
       ? localFile(module.uri)
       : remoteAsset(module.uri);

--- a/packages/webgltexture-loader-expo/src/ExpoModuleTextureLoader.js
+++ b/packages/webgltexture-loader-expo/src/ExpoModuleTextureLoader.js
@@ -4,7 +4,7 @@ import {
   WebGLTextureLoaderAsyncHashCache
 } from "webgltexture-loader";
 import { Image } from "react-native";
-import Expo from "expo";
+import { Asset, FileSystem } from "expo";
 import md5 from "./md5";
 
 const neverEnding = new Promise(() => {});
@@ -20,7 +20,7 @@ const hash = (module: number | { uri: string }) =>
   typeof module === "number" ? module : module.uri;
 
 const localAsset = (module: number) => {
-  const asset = Expo.Asset.fromModule(module);
+  const asset = Asset.fromModule(module);
   return asset.downloadAsync().then(() => asset);
 };
 
@@ -37,9 +37,9 @@ const remoteAsset = (uri: string) => {
     new Promise((success, failure) =>
       Image.getSize(uri, (width, height) => success({ width, height }), failure)
     ),
-    Expo.FileSystem.downloadAsync(
+    FileSystem.downloadAsync(
       uri,
-      Expo.FileSystem.documentDirectory + `ExponentAsset-${key}${ext}`,
+      FileSystem.documentDirectory + `ExponentAsset-${key}${ext}`,
       {
         cache: true
       }

--- a/packages/webgltexture-loader-expo/src/ExpoModuleTextureLoader.js
+++ b/packages/webgltexture-loader-expo/src/ExpoModuleTextureLoader.js
@@ -9,7 +9,7 @@ import md5 from "./md5";
 
 const neverEnding = new Promise(() => {});
 
-type Asset = {
+type AssetType = {
   width: number,
   height: number,
   uri: string,
@@ -63,7 +63,7 @@ const localFile = (uri: string) => {
   return promise;
 };
 
-export const loadAsset = (module: number | { uri: string }): Promise<Asset> =>
+export const loadAsset = (module: number | { uri: string }): Promise<AssetType> =>
   typeof module === "number"
     ? localAsset(module)
     : module.uri.startsWith("file:") ||

--- a/packages/webgltexture-loader-expo/src/ExpoModuleTextureLoader.js
+++ b/packages/webgltexture-loader-expo/src/ExpoModuleTextureLoader.js
@@ -66,7 +66,11 @@ const localFile = (uri: string) => {
 export const loadAsset = (module: number | { uri: string }): Promise<Asset> =>
   typeof module === "number"
     ? localAsset(module)
-    : module.uri.startsWith("file:") || module.uri.startsWith("data:")
+    : module.uri.startsWith("file:") ||
+      module.uri.startsWith("data:") ||
+      module.uri.startsWith("asset:") || // All local paths in Android Expo standalone app
+      module.uri.startsWith("assets-library:") || // CameraRoll.getPhotos
+      module.uri.startsWith("/") // Expo.takeSnapshotAsync in DEV in Expo 31
       ? localFile(module.uri)
       : remoteAsset(module.uri);
 


### PR DESCRIPTION
This pull request fixes texture loader for Expo apps. It adds missing protocols in valid local asset path protocols
```
module.uri.startsWith("asset:")                  // All local paths in Android Expo standalone app
module.uri.startsWith("assets-library:")    // CameraRoll.getPhotos iOS
module.uri.startsWith("content:")              // CameraRoll.getPhotos Android
module.uri.startsWith("/")                           // Expo.takeSnapshotAsync in DEV in Expo 31
```

This pull request also replaces default import from Expo on partial because it was deprecated and will be removed in Expo 32. Also default import from Expo causes multiple warnings messages, which makes the development process on Android very slow.