### PR TITLE
Switch to es2016 for Expo

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["flow", "es2015", "stage-1"]
+  "presets": ["flow", "es2016", "stage-1"]
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "babel-cli": "6",
     "babel-jest": "20",
-    "babel-preset-es2015": "6",
+    "babel-preset-es2016": "6",
     "babel-preset-flow": "6",
     "babel-preset-stage-1": "6",
     "flow-copy-source": "1",


### PR DESCRIPTION
This is needed in order to avoid deprecation warning from expo.