### PR TITLE
Fix broken NativeModules.ExponentGLObjectManager

### DIFF
--- a/packages/webgltexture-loader-expo/package.json
+++ b/packages/webgltexture-loader-expo/package.json
@@ -12,7 +12,8 @@
   "license": "MIT",
   "peerDependencies": {
     "expo-camera": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "@unimodules/core": "*"
   },
   "dependencies": {
     "webgltexture-loader": "^0.12.2"

--- a/packages/webgltexture-loader-expo/src/DeprecatedExpoGLObjectTextureLoader.js
+++ b/packages/webgltexture-loader-expo/src/DeprecatedExpoGLObjectTextureLoader.js
@@ -3,13 +3,13 @@ import {
   globalRegistry,
   WebGLTextureLoaderAsyncHashCache
 } from "webgltexture-loader";
-import { NativeModules } from "react-native";
+import { NativeModulesProxy } from "@unimodules/core";
 
 const neverEnding = new Promise(() => {});
 
 const available = !!(
-  NativeModules.ExponentGLObjectManager &&
-  NativeModules.ExponentGLObjectManager.createObjectAsync
+  NativeModulesProxy.ExponentGLObjectManager &&
+  NativeModulesProxy.ExponentGLObjectManager.createObjectAsync
 );
 
 let warned = false;
@@ -34,7 +34,7 @@ class ExpoGLObjectTextureLoader extends WebGLTextureLoaderAsyncHashCache<
   disposeTexture(texture: WebGLTexture) {
     const exglObjId = this.objIds.get(texture);
     if (exglObjId) {
-      NativeModules.ExponentGLObjectManager.destroyObjectAsync(exglObjId);
+      NativeModulesProxy.ExponentGLObjectManager.destroyObjectAsync(exglObjId);
     }
     this.objIds.delete(texture);
   }
@@ -52,7 +52,7 @@ class ExpoGLObjectTextureLoader extends WebGLTextureLoaderAsyncHashCache<
     const dispose = () => {
       disposed = true;
     };
-    const promise = NativeModules.ExponentGLObjectManager.createObjectAsync({
+    const promise = NativeModulesProxy.ExponentGLObjectManager.createObjectAsync({
       exglCtxId,
       texture: config
     }).then(({ exglObjId }) => {

--- a/packages/webgltexture-loader-expo/src/ExpoCameraTextureLoader.js
+++ b/packages/webgltexture-loader-expo/src/ExpoCameraTextureLoader.js
@@ -3,14 +3,15 @@ import {
   globalRegistry,
   WebGLTextureLoaderAsyncHashCache
 } from "webgltexture-loader";
-import { NativeModules, findNodeHandle } from "react-native";
+import { findNodeHandle } from "react-native";
+import { NativeModulesProxy } from "@unimodules/core";
 import { Camera } from "expo-camera";
 
 const neverEnding = new Promise(() => {});
 
 const available = !!(
-  NativeModules.ExponentGLObjectManager &&
-  NativeModules.ExponentGLObjectManager.createCameraTextureAsync
+  NativeModulesProxy.ExponentGLObjectManager &&
+  NativeModulesProxy.ExponentGLObjectManager.createCameraTextureAsync
 );
 
 let warned = false;
@@ -36,7 +37,7 @@ class ExpoCameraTextureLoader extends WebGLTextureLoaderAsyncHashCache<Camera> {
   disposeTexture(texture: WebGLTexture) {
     const exglObjId = this.objIds.get(texture);
     if (exglObjId) {
-      NativeModules.ExponentGLObjectManager.destroyObjectAsync(exglObjId);
+      NativeModulesProxy.ExponentGLObjectManager.destroyObjectAsync(exglObjId);
     }
     this.objIds.delete(texture);
   }


### PR DESCRIPTION
Due to Expo shifting things around with their constant updates,
ExponentGLObjectManager has been moved from NativeModules to
NativeModulesProxy, thus breaking some functionality (
the deprecated DeprecatedExpoGLObjectTextureLoader but also
and most importantly the ExpoCameraTextureLoader). With this fix,
people trying to obtain a texture from their camera should
be able to do so again.