### PR TITLE
Expo SDK 43 Support

### DIFF
--- a/packages/webgltexture-loader-expo-camera/package.json
+++ b/packages/webgltexture-loader-expo-camera/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webgltexture-loader-expo-camera",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "load camera expo 'config' object for webgltexture-loader",
   "main": "lib/index.js",
   "files": [
@@ -11,7 +11,7 @@
   "author": "Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "@unimodules/core": "*",
+    "expo-modules-core": "*",
     "expo-camera": "*",
     "react-native": "*"
   },

--- a/packages/webgltexture-loader-expo-camera/src/ExpoCameraTextureLoader.js
+++ b/packages/webgltexture-loader-expo-camera/src/ExpoCameraTextureLoader.js
@@ -4,10 +4,10 @@ import {
   WebGLTextureLoaderAsyncHashCache
 } from "webgltexture-loader";
 import { findNodeHandle } from "react-native";
-import { NativeModulesProxy } from "@unimodules/core";
+import { NativeModulesProxy } from "expo-modules-core";
 import { Camera } from "expo-camera";
 
-const neverEnding = new Promise(() => {});
+const neverEnding = new Promise(() => { });
 
 const available = !!(
   NativeModulesProxy.ExponentGLObjectManager &&
@@ -58,14 +58,14 @@ class ExpoCameraTextureLoader extends WebGLTextureLoaderAsyncHashCache<Camera> {
     const promise: Promise<*> = !glView
       ? Promise.reject(new Error("GLViewRef not available"))
       : glView.createCameraTextureAsync(camera).then(texture => {
-          if (disposed) return neverEnding;
-          // $FlowFixMe
-          this.objIds.set(texture, texture.exglObjId);
-          const width = 0;
-          const height = 0;
-          // ^ any way to retrieve these ?
-          return { texture, width, height };
-        });
+        if (disposed) return neverEnding;
+        // $FlowFixMe
+        this.objIds.set(texture, texture.exglObjId);
+        const width = 0;
+        const height = 0;
+        // ^ any way to retrieve these ?
+        return { texture, width, height };
+      });
     return { promise, dispose };
   }
 }

--- a/packages/webgltexture-loader-expo/package.json
+++ b/packages/webgltexture-loader-expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webgltexture-loader-expo",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "load basic expo 'config' object for webgltexture-loader",
   "main": "lib/index.js",
   "files": [
@@ -11,7 +11,7 @@
   "author": "Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "@unimodules/core": "*",
+    "expo-modules-core": "*",
     "react-native": "*"
   },
   "dependencies": {

--- a/packages/webgltexture-loader-expo/src/DeprecatedExpoGLObjectTextureLoader.js
+++ b/packages/webgltexture-loader-expo/src/DeprecatedExpoGLObjectTextureLoader.js
@@ -3,9 +3,9 @@ import {
   globalRegistry,
   WebGLTextureLoaderAsyncHashCache
 } from "webgltexture-loader";
-import { NativeModulesProxy } from "@unimodules/core";
+import { NativeModulesProxy } from "expo-modules-core";
 
-const neverEnding = new Promise(() => {});
+const neverEnding = new Promise(() => { });
 
 const available = !!(
   NativeModulesProxy.ExponentGLObjectManager &&


### PR DESCRIPTION
Expo SDK 43 removes the unimodules system. This PR updates imports to use Expo Modules instead for support in SDK43.