### PR TITLE
fix(expo): fix image resolution issue

### DIFF
--- a/packages/webgltexture-loader-expo/package.json
+++ b/packages/webgltexture-loader-expo/package.json
@@ -15,7 +15,6 @@
     "react-native": "*"
   },
   "dependencies": {
-    "expo-asset-utils": "^3.0.0",
     "webgltexture-loader": "^2.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3636,11 +3636,6 @@ expect@^28.1.0:
     jest-message-util "^28.1.0"
     jest-util "^28.1.0"
 
-expo-asset-utils@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/expo-asset-utils/-/expo-asset-utils-3.0.0.tgz#2c7ddf71ba9efacf7b46c159c1c650114a2f14dc"
-  integrity sha512-CgIbNvTqKqQi1lrlptmwoaCMu4ZVOZf8tghmytlor23CjIOuorw6cfuOqiqWkJLz23arTt91maYEU9XLMPB23A==
-
 extend-shallow@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"


### PR DESCRIPTION
`expo-asset-utils` is now deprecated and no longer maintained. Additionally, when loading external images using `expo-asset` on iOS and Android, the width and height are null. This pull request is a workaround for that issue.

https://github.com/expo/expo/blob/d8d7919/packages/expo-asset/src/Asset.ts#L251-L261