### PR TITLE
Lint (oxlint), format (oxfmt), CI workflow, headless-gl tests

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,0 +1,50 @@
+name: CI tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - run: corepack enable
+      - name: Get yarn cache dir
+        id: yarn-cache-dir
+        run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.yarn-cache-dir.outputs.dir }}
+          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: yarn-${{ runner.os }}-
+      - run: yarn install --immutable
+      - run: yarn lint
+      - run: yarn format
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # headless-gl ships prebuilt Linux binaries; only xvfb + libGL runtime needed.
+      - run: sudo apt-get update && sudo apt-get install -y xvfb libgl1 libxi6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - run: corepack enable
+      - name: Get yarn cache dir
+        id: yarn-cache-dir
+        run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.yarn-cache-dir.outputs.dir }}
+          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: yarn-${{ runner.os }}-
+      - run: yarn install --immutable
+      - run: yarn build
+      - run: xvfb-run -s "-ac -screen 0 1280x1024x24" yarn test

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "categories": {
+    "correctness": "error",
+    "suspicious": "warn",
+    "perf": "warn",
+    "style": "off"
+  },
+  "rules": {
+    "no-explicit-any": "off",
+    "no-non-null-assertion": "off",
+    "no-underscore-dangle": "off",
+    "no-extraneous-class": "off",
+    "prefer-add-event-listener": "off",
+    "consistent-function-scoping": "off"
+  },
+  "ignorePatterns": ["**/lib/**", "**/node_modules/**", ".yarn/**"]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,3 +16,5 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Yarn 4 is pinned via Corepack (`packageManager` field). If `yarn` is shimmed by `proto` and refuses to run, invoke `corepack yarn ...` instead.
 - Source is TypeScript. Build is per-package `tsc` orchestrated by `yarn workspaces foreach -Apt run build` from the root (parallel topological). Tests are transformed by `ts-jest`.
 - Peer-deps for the Expo and React Native loaders are not installed; minimal type stubs live in `packages/*/src/types.d.ts` files. Don't try to install `expo-camera` / `react-native` to type-check — keep the stubs minimal.
+- Lint / format are oxc tools: `yarn lint` (oxlint) and `yarn format` (oxfmt --check) / `yarn format:fix`. `oxfmt` has no config file yet — it uses defaults.
+- Headless GL tests use the `gl` package (`9.0.0-rc.10` for Node 24 compat). They're suffixed `*.gl.test.ts` and skip themselves if `require("gl")` throws (so local macOS without the prebuilt binding still passes the rest of the suite). CI installs `xvfb + mesa` and runs the suite under `xvfb-run`.

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   // NodeNext requires explicit `.js` extensions in TS source. Strip them at
   // resolution time so Jest finds the actual `.ts` file.
   moduleNameMapper: {
-    "^(\\.{1,2}/.+)\\.js$": "$1"
+    "^(\\.{1,2}/.+)\\.js$": "$1",
   },
   transform: {
     "^.+\\.tsx?$": [
@@ -15,11 +15,11 @@ module.exports = {
           moduleResolution: "NodeNext",
           esModuleInterop: true,
           isolatedModules: true,
-          lib: ["ES2022", "DOM"],
-          types: ["jest", "node"]
-        }
-      }
-    ]
+          lib: ["ES2023", "DOM"],
+          types: ["jest", "node"],
+        },
+      },
+    ],
   },
-  testMatch: ["**/src/**/*.test.{ts,tsx,js,jsx}"]
+  testMatch: ["**/src/**/*.test.{ts,tsx,js,jsx}"],
 };

--- a/package.json
+++ b/package.json
@@ -1,31 +1,43 @@
 {
-  "private": true,
   "name": "webgltexture-loader-libs",
   "version": "0.0.0",
+  "private": true,
+  "description": "Generic & extensible texture loader utility",
+  "license": "MIT",
+  "author": "Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>",
+  "repository": "https://github.com/gre/webgltexture-loader",
   "workspaces": [
     "packages/*"
   ],
-  "description": "Generic & extensible texture loader utility",
-  "repository": "https://github.com/gre/webgltexture-loader",
-  "author": "Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>",
-  "license": "MIT",
-  "engines": {
-    "node": ">=22"
+  "scripts": {
+    "test": "jest",
+    "build": "yarn workspaces foreach -Apt run build",
+    "lint": "oxlint",
+    "format": "oxfmt --check \"packages/**/*.{ts,tsx}\" \"jest.config.js\"",
+    "format:fix": "oxfmt \"packages/**/*.{ts,tsx}\" \"jest.config.js\"",
+    "typecheck": "yarn workspaces foreach -A run typecheck",
+    "changeset:version": "changeset version",
+    "release": "yarn build && changeset publish"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0",
     "@types/jest": "^30.0.0",
     "@types/ndarray": "^1.0.14",
     "@types/node": "^25.6.0",
+    "gl": "^9.0.0-rc.10",
     "jest": "^30.3.0",
+    "oxfmt": "^0.47.0",
+    "oxlint": "^1.62.0",
     "ts-jest": "^29",
     "typescript": "^6"
   },
-  "scripts": {
-    "test": "jest",
-    "build": "yarn workspaces foreach -Apt run build",
-    "changeset:version": "changeset version",
-    "release": "yarn build && changeset publish"
+  "dependenciesMeta": {
+    "gl": {
+      "built": true
+    }
+  },
+  "engines": {
+    "node": ">=22"
   },
   "packageManager": "yarn@4.14.1+sha512.64df448055b2d37ba269d7db535a469b8da93f8ef1140c25fd7a83c00a8fbaacb214ca0e02553b92a2c54cef78bb67d0b4817fab02001df0e24fac0faccc3b42"
 }

--- a/packages/webgltexture-loader-dom-canvas/package.json
+++ b/packages/webgltexture-loader-dom-canvas/package.json
@@ -2,19 +2,20 @@
   "name": "webgltexture-loader-dom-canvas",
   "version": "2.0.0",
   "description": "HTMLCanvasElement loader for webgltexture-loader",
-  "main": "lib/CanvasTextureLoader.js",
+  "license": "MIT",
+  "author": "Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>",
+  "repository": "https://github.com/gre/webgltexture-loader",
   "files": [
     "src",
     "lib"
   ],
-  "repository": "https://github.com/gre/webgltexture-loader",
-  "author": "Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>",
-  "license": "MIT",
-  "dependencies": {
-    "webgltexture-loader": "^2.0.0"
-  },
+  "main": "lib/CanvasTextureLoader.js",
   "types": "lib/CanvasTextureLoader.d.ts",
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "webgltexture-loader": "^2.0.0"
   }
 }

--- a/packages/webgltexture-loader-dom-canvas/src/CanvasTextureLoader.ts
+++ b/packages/webgltexture-loader-dom-canvas/src/CanvasTextureLoader.ts
@@ -1,7 +1,7 @@
 import {
-  WebGLTextureLoaderSyncHashCache,
   createTexture,
   globalRegistry,
+  WebGLTextureLoaderSyncHashCache,
 } from "webgltexture-loader";
 
 export default class CanvasTextureLoader extends WebGLTextureLoaderSyncHashCache<HTMLCanvasElement> {

--- a/packages/webgltexture-loader-dom-image-url/package.json
+++ b/packages/webgltexture-loader-dom-image-url/package.json
@@ -2,19 +2,20 @@
   "name": "webgltexture-loader-dom-image-url",
   "version": "2.0.0",
   "description": "load an Image by its URL for webgltexture-loader",
-  "main": "lib/ImageURLTextureLoader.js",
+  "license": "MIT",
+  "author": "Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>",
+  "repository": "https://github.com/gre/webgltexture-loader",
   "files": [
     "src",
     "lib"
   ],
-  "repository": "https://github.com/gre/webgltexture-loader",
-  "author": "Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>",
-  "license": "MIT",
-  "dependencies": {
-    "webgltexture-loader": "^2.0.0"
-  },
+  "main": "lib/ImageURLTextureLoader.js",
   "types": "lib/ImageURLTextureLoader.d.ts",
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "webgltexture-loader": "^2.0.0"
   }
 }

--- a/packages/webgltexture-loader-dom-image-url/src/ImageURLTextureLoader.ts
+++ b/packages/webgltexture-loader-dom-image-url/src/ImageURLTextureLoader.ts
@@ -7,7 +7,7 @@ import {
 function loadImage(
   src: string,
   success: (img: HTMLImageElement) => void,
-  failure: (e: unknown) => void
+  failure: (e: unknown) => void,
 ): () => void {
   let img: HTMLImageElement | null = new window.Image();
   if (src.slice(0, 5) !== "data:") {
@@ -45,7 +45,7 @@ export default class ImageURLTextureLoader extends WebGLTextureLoaderAsyncHashCa
     let dispose: () => void = () => {};
     const promise = new Promise<HTMLImageElement>((resolve, reject) => {
       dispose = loadImage(src, resolve, (e) =>
-        reject(new Error("image load failed", { cause: e }))
+        reject(new Error("image load failed", { cause: e })),
       );
     }).then((img) => {
       const { width, height } = img;

--- a/packages/webgltexture-loader-dom-video/package.json
+++ b/packages/webgltexture-loader-dom-video/package.json
@@ -2,19 +2,20 @@
   "name": "webgltexture-loader-dom-video",
   "version": "2.0.0",
   "description": "HTMLVideoElement loader for webgltexture-loader",
-  "main": "lib/VideoTextureLoader.js",
+  "license": "MIT",
+  "author": "Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>",
+  "repository": "https://github.com/gre/webgltexture-loader",
   "files": [
     "src",
     "lib"
   ],
-  "repository": "https://github.com/gre/webgltexture-loader",
-  "author": "Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>",
-  "license": "MIT",
-  "dependencies": {
-    "webgltexture-loader": "^2.0.0"
-  },
+  "main": "lib/VideoTextureLoader.js",
   "types": "lib/VideoTextureLoader.d.ts",
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "webgltexture-loader": "^2.0.0"
   }
 }

--- a/packages/webgltexture-loader-dom-video/src/VideoTextureLoader.ts
+++ b/packages/webgltexture-loader-dom-video/src/VideoTextureLoader.ts
@@ -1,7 +1,7 @@
 import {
-  WebGLTextureLoaderAsyncHashCache,
   createTexture,
   globalRegistry,
+  WebGLTextureLoaderAsyncHashCache,
 } from "webgltexture-loader";
 
 export default class VideoTextureLoader extends WebGLTextureLoaderAsyncHashCache<HTMLVideoElement> {
@@ -29,14 +29,7 @@ export default class VideoTextureLoader extends WebGLTextureLoaderAsyncHashCache
           const { videoWidth: width, videoHeight: height } = input;
           const texture = createTexture(gl);
           gl.bindTexture(gl.TEXTURE_2D, texture);
-          gl.texImage2D(
-            gl.TEXTURE_2D,
-            0,
-            gl.RGBA,
-            gl.RGBA,
-            gl.UNSIGNED_BYTE,
-            input
-          );
+          gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, input);
           resolve({ texture, width, height });
         } else {
           timeout = setTimeout(checkVideoReady, 100);

--- a/packages/webgltexture-loader-dom/package.json
+++ b/packages/webgltexture-loader-dom/package.json
@@ -2,21 +2,22 @@
   "name": "webgltexture-loader-dom",
   "version": "2.0.0",
   "description": "collection of webgltexture-loader in DOM implementation context",
-  "main": "lib/index.js",
+  "license": "MIT",
+  "author": "Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>",
+  "repository": "https://github.com/gre/webgltexture-loader",
   "files": [
     "src",
     "lib"
   ],
-  "repository": "https://github.com/gre/webgltexture-loader",
-  "author": "Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>",
-  "license": "MIT",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
   "dependencies": {
     "webgltexture-loader-dom-canvas": "^2.0.0",
     "webgltexture-loader-dom-image-url": "^2.0.0",
     "webgltexture-loader-dom-video": "^2.0.0"
-  },
-  "types": "lib/index.d.ts",
-  "scripts": {
-    "build": "tsc"
   }
 }

--- a/packages/webgltexture-loader-dom/src/index.ts
+++ b/packages/webgltexture-loader-dom/src/index.ts
@@ -1,5 +1,5 @@
 import CanvasTextureLoader from "webgltexture-loader-dom-canvas";
-import VideoTextureLoader from "webgltexture-loader-dom-video";
 import ImageURLTextureLoader from "webgltexture-loader-dom-image-url";
+import VideoTextureLoader from "webgltexture-loader-dom-video";
 
-export { CanvasTextureLoader, VideoTextureLoader, ImageURLTextureLoader };
+export { CanvasTextureLoader, ImageURLTextureLoader, VideoTextureLoader };

--- a/packages/webgltexture-loader-expo-camera/package.json
+++ b/packages/webgltexture-loader-expo-camera/package.json
@@ -2,24 +2,25 @@
   "name": "webgltexture-loader-expo-camera",
   "version": "2.0.0",
   "description": "load camera expo 'config' object for webgltexture-loader",
-  "main": "lib/index.js",
+  "license": "MIT",
+  "author": "Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>",
+  "repository": "https://github.com/gre/webgltexture-loader",
   "files": [
     "src",
     "lib"
   ],
-  "repository": "https://github.com/gre/webgltexture-loader",
-  "author": "Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>",
-  "license": "MIT",
-  "peerDependencies": {
-    "expo-camera": "*",
-    "expo-modules-core": "*",
-    "react-native": "*"
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "webgltexture-loader": "^2.0.0"
   },
-  "types": "lib/index.d.ts",
-  "scripts": {
-    "build": "tsc"
+  "peerDependencies": {
+    "expo-camera": "*",
+    "expo-modules-core": "*",
+    "react-native": "*"
   }
 }

--- a/packages/webgltexture-loader-expo-camera/src/ExpoCameraTextureLoader.ts
+++ b/packages/webgltexture-loader-expo-camera/src/ExpoCameraTextureLoader.ts
@@ -1,24 +1,16 @@
-import {
-  globalRegistry,
-  WebGLTextureLoaderAsyncHashCache,
-} from "webgltexture-loader";
-import { findNodeHandle } from "react-native";
-import { NativeModulesProxy } from "expo-modules-core";
 import { Camera } from "expo-camera";
+import { NativeModulesProxy } from "expo-modules-core";
+import { findNodeHandle } from "react-native";
+import { globalRegistry, WebGLTextureLoaderAsyncHashCache } from "webgltexture-loader";
 
 const neverEnding: Promise<never> = new Promise(() => {});
 
-const available = !!(
-  NativeModulesProxy.ExponentGLObjectManager &&
-  NativeModulesProxy.ExponentGLObjectManager.createCameraTextureAsync
-);
+const available = !!NativeModulesProxy.ExponentGLObjectManager?.createCameraTextureAsync;
 
 let warned = false;
 
 interface GLViewRefExtension {
-  createCameraTextureAsync(
-    camera: Camera
-  ): Promise<WebGLTexture & { exglObjId: number }>;
+  createCameraTextureAsync(camera: Camera): Promise<WebGLTexture & { exglObjId: number }>;
 }
 
 export default class ExpoCameraTextureLoader extends WebGLTextureLoaderAsyncHashCache<Camera> {
@@ -32,7 +24,7 @@ export default class ExpoCameraTextureLoader extends WebGLTextureLoaderAsyncHash
       if (!warned) {
         warned = true;
         console.log(
-          "webgltexture-loader-expo: ExponentGLObjectManager.createCameraTextureAsync is not available. Make sure to use the correct version of Expo"
+          "webgltexture-loader-expo: ExponentGLObjectManager.createCameraTextureAsync is not available. Make sure to use the correct version of Expo",
         );
       }
     }
@@ -42,9 +34,7 @@ export default class ExpoCameraTextureLoader extends WebGLTextureLoaderAsyncHash
   override disposeTexture(texture: WebGLTexture): void {
     const exglObjId = this.objIds.get(texture);
     if (exglObjId !== undefined) {
-      NativeModulesProxy.ExponentGLObjectManager?.destroyObjectAsync?.(
-        exglObjId
-      );
+      NativeModulesProxy.ExponentGLObjectManager?.destroyObjectAsync?.(exglObjId);
     }
     this.objIds.delete(texture);
   }

--- a/packages/webgltexture-loader-expo/package.json
+++ b/packages/webgltexture-loader-expo/package.json
@@ -2,24 +2,25 @@
   "name": "webgltexture-loader-expo",
   "version": "2.0.0",
   "description": "load basic expo 'config' object for webgltexture-loader",
-  "main": "lib/index.js",
+  "license": "MIT",
+  "author": "Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>",
+  "repository": "https://github.com/gre/webgltexture-loader",
   "files": [
     "src",
     "lib"
   ],
-  "repository": "https://github.com/gre/webgltexture-loader",
-  "author": "Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>",
-  "license": "MIT",
-  "peerDependencies": {
-    "expo-modules-core": "*",
-    "react-native": "*"
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "expo-asset-utils": "^3.0.0",
     "webgltexture-loader": "^2.0.0"
   },
-  "types": "lib/index.d.ts",
-  "scripts": {
-    "build": "tsc"
+  "peerDependencies": {
+    "expo-modules-core": "*",
+    "react-native": "*"
   }
 }

--- a/packages/webgltexture-loader-expo/src/DeprecatedExpoGLObjectTextureLoader.ts
+++ b/packages/webgltexture-loader-expo/src/DeprecatedExpoGLObjectTextureLoader.ts
@@ -1,15 +1,9 @@
-import {
-  globalRegistry,
-  WebGLTextureLoaderAsyncHashCache,
-} from "webgltexture-loader";
 import { NativeModulesProxy } from "expo-modules-core";
+import { globalRegistry, WebGLTextureLoaderAsyncHashCache } from "webgltexture-loader";
 
 const neverEnding: Promise<never> = new Promise(() => {});
 
-const available = !!(
-  NativeModulesProxy.ExponentGLObjectManager &&
-  NativeModulesProxy.ExponentGLObjectManager.createObjectAsync
-);
+const available = !!NativeModulesProxy.ExponentGLObjectManager?.createObjectAsync;
 
 let warned = false;
 
@@ -24,7 +18,7 @@ export default class ExpoGLObjectTextureLoader extends WebGLTextureLoaderAsyncHa
     if (!available && !warned) {
       warned = true;
       console.log(
-        "webgltexture-loader-expo: ExponentGLObjectManager.createObjectAsync is not available. Make sure to use the correct version of Expo"
+        "webgltexture-loader-expo: ExponentGLObjectManager.createObjectAsync is not available. Make sure to use the correct version of Expo",
       );
     }
     return available && typeof input === "object" && input !== null;
@@ -33,9 +27,7 @@ export default class ExpoGLObjectTextureLoader extends WebGLTextureLoaderAsyncHa
   override disposeTexture(texture: WebGLTexture): void {
     const exglObjId = this.objIds.get(texture);
     if (exglObjId !== undefined) {
-      NativeModulesProxy.ExponentGLObjectManager?.destroyObjectAsync?.(
-        exglObjId
-      );
+      NativeModulesProxy.ExponentGLObjectManager?.destroyObjectAsync?.(exglObjId);
     }
     this.objIds.delete(texture);
   }
@@ -47,25 +39,35 @@ export default class ExpoGLObjectTextureLoader extends WebGLTextureLoaderAsyncHa
   override loadNoCache(config: Record<string, unknown>) {
     const { gl } = this;
     const { __exglCtxId: exglCtxId } = gl as unknown as { __exglCtxId: number };
+    const createObjectAsync = NativeModulesProxy.ExponentGLObjectManager?.createObjectAsync;
+    if (!createObjectAsync) {
+      return {
+        promise: Promise.reject(
+          new Error("ExponentGLObjectManager.createObjectAsync not available"),
+        ),
+        dispose: () => {},
+      };
+    }
     let disposed = false;
     const dispose = () => {
       disposed = true;
     };
-    const promise =
-      NativeModulesProxy.ExponentGLObjectManager!.createObjectAsync!({
-        exglCtxId,
-        texture: config,
-      }).then(({ exglObjId }) => {
-        if (disposed) return neverEnding;
-        // Expo polyfills a constructible WebGLTexture(exglObjId) on the global.
-        // Standard browsers expose WebGLTexture as an opaque, non-constructible
-        // interface; this code only runs under Expo.
-        const texture = new (
-          globalThis as unknown as { WebGLTexture: new (id: number) => WebGLTexture }
-        ).WebGLTexture(exglObjId);
-        this.objIds.set(texture, exglObjId);
-        return { texture, width: 0, height: 0 };
-      });
+    const promise = createObjectAsync({
+      exglCtxId,
+      texture: config,
+    }).then(({ exglObjId }) => {
+      if (disposed) return neverEnding;
+      // Expo polyfills a constructible WebGLTexture(exglObjId) on the global.
+      // Standard browsers expose WebGLTexture as an opaque, non-constructible
+      // interface; this code only runs under Expo.
+      const texture = new (
+        globalThis as unknown as {
+          WebGLTexture: new (id: number) => WebGLTexture;
+        }
+      ).WebGLTexture(exglObjId);
+      this.objIds.set(texture, exglObjId);
+      return { texture, width: 0, height: 0 };
+    });
     return { promise, dispose };
   }
 }

--- a/packages/webgltexture-loader-expo/src/ExpoModuleTextureLoader.ts
+++ b/packages/webgltexture-loader-expo/src/ExpoModuleTextureLoader.ts
@@ -1,10 +1,10 @@
+import { Asset } from "expo-asset";
+import * as AssetUtils from "expo-asset-utils";
 import {
   createTexture,
   globalRegistry,
   WebGLTextureLoaderAsyncHashCache,
 } from "webgltexture-loader";
-import * as AssetUtils from "expo-asset-utils";
-import { Asset } from "expo-asset";
 
 const neverEnding: Promise<never> = new Promise(() => {});
 
@@ -60,7 +60,7 @@ export default class ExpoModuleTextureLoader extends WebGLTextureLoaderAsyncHash
       // pass NaN to texImage2D.
       if (typeof width !== "number" || typeof height !== "number") {
         throw new Error(
-          `Expo asset has no dimensions (width=${width}, height=${height}, uri=${uri})`
+          `Expo asset has no dimensions (width=${width}, height=${height}, uri=${uri})`,
         );
       }
       const texture = createTexture(gl);
@@ -76,7 +76,7 @@ export default class ExpoModuleTextureLoader extends WebGLTextureLoaderAsyncHash
         0,
         gl.RGBA,
         gl.UNSIGNED_BYTE,
-        asset as unknown as ArrayBufferView
+        asset as unknown as ArrayBufferView,
       );
       return { texture, width, height };
     });

--- a/packages/webgltexture-loader-ndarray/package.json
+++ b/packages/webgltexture-loader-ndarray/package.json
@@ -2,22 +2,23 @@
   "name": "webgltexture-loader-ndarray",
   "version": "2.0.0",
   "description": "ndarray loader for webgltexture-loader",
-  "main": "lib/NDArrayTextureLoader.js",
+  "license": "MIT",
+  "author": "Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>",
+  "repository": "https://github.com/gre/webgltexture-loader",
   "files": [
     "src",
     "lib"
   ],
-  "repository": "https://github.com/gre/webgltexture-loader",
-  "author": "Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>",
-  "license": "MIT",
+  "main": "lib/NDArrayTextureLoader.js",
+  "types": "lib/NDArrayTextureLoader.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
   "dependencies": {
     "ndarray": "^1.0.19",
     "ndarray-ops": "^1.2.2",
     "typedarray-pool": "^1.2.0",
     "webgltexture-loader": "^2.0.0"
-  },
-  "types": "lib/NDArrayTextureLoader.d.ts",
-  "scripts": {
-    "build": "tsc"
   }
 }

--- a/packages/webgltexture-loader-ndarray/src/NDArrayTextureLoader.gl.test.ts
+++ b/packages/webgltexture-loader-ndarray/src/NDArrayTextureLoader.gl.test.ts
@@ -1,0 +1,109 @@
+import ndarray from "ndarray";
+import NDArrayTextureLoader from "./NDArrayTextureLoader.js";
+
+let createGL: ((w: number, h: number) => WebGLRenderingContext) | null = null;
+try {
+  createGL = require("gl");
+} catch {
+  createGL = null;
+}
+
+const describeGL = createGL ? describe : describe.skip;
+
+function destroy(gl: WebGLRenderingContext): void {
+  (gl.getExtension("STACKGL_destroy_context") as { destroy(): void } | null)?.destroy();
+}
+
+function readPixel(gl: WebGLRenderingContext, texture: WebGLTexture): Uint8Array {
+  const fb = gl.createFramebuffer();
+  gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+  gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+  const out = new Uint8Array(4);
+  gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, out);
+  gl.deleteFramebuffer(fb);
+  return out;
+}
+
+describeGL("NDArrayTextureLoader against headless-gl", () => {
+  let gl: WebGLRenderingContext;
+
+  beforeEach(() => {
+    gl = createGL!(2, 2);
+  });
+
+  afterEach(() => {
+    destroy(gl);
+  });
+
+  test("uploads a uint8 RGBA ndarray and reports its size", () => {
+    const loader = new NDArrayTextureLoader(gl);
+    const data = new Uint8Array([255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 0, 255]);
+    const arr = ndarray(data, [2, 2, 4]);
+    const result = loader.get(arr);
+    expect(result.width).toBe(2);
+    expect(result.height).toBe(2);
+    expect(gl.isTexture(result.texture)).toBe(true);
+    expect(Array.from(readPixel(gl, result.texture))).toEqual([255, 0, 0, 255]);
+    loader.dispose();
+    expect(gl.isTexture(result.texture)).toBe(false);
+  });
+
+  test("dispose deletes every cached texture", () => {
+    const loader = new NDArrayTextureLoader(gl);
+    const arrA = ndarray(new Uint8Array([255, 0, 0, 255]), [1, 1, 4]);
+    const arrB = ndarray(new Uint8Array([0, 255, 0, 255]), [1, 1, 4]);
+    const a = loader.get(arrA);
+    const b = loader.get(arrB);
+    expect(gl.isTexture(a.texture)).toBe(true);
+    expect(gl.isTexture(b.texture)).toBe(true);
+    loader.dispose();
+    expect(gl.isTexture(a.texture)).toBe(false);
+    expect(gl.isTexture(b.texture)).toBe(false);
+  });
+
+  test("update() re-uploads texture data without recreating it", () => {
+    const loader = new NDArrayTextureLoader(gl);
+    const arr = ndarray(new Uint8Array([255, 0, 0, 255]), [1, 1, 4]);
+    const first = loader.get(arr);
+    expect(Array.from(readPixel(gl, first.texture))).toEqual([255, 0, 0, 255]);
+    arr.data[0] = 0;
+    arr.data[1] = 255;
+    loader.update(arr);
+    expect(loader.get(arr).texture).toBe(first.texture);
+    expect(Array.from(readPixel(gl, first.texture))).toEqual([0, 255, 0, 255]);
+    loader.dispose();
+  });
+
+  test("uploads a 2D ndarray as LUMINANCE", () => {
+    const loader = new NDArrayTextureLoader(gl);
+    const arr = ndarray(new Uint8Array([42]), [1, 1]);
+    const result = loader.get(arr);
+    expect(result.width).toBe(1);
+    expect(result.height).toBe(1);
+    expect(gl.isTexture(result.texture)).toBe(true);
+    loader.dispose();
+  });
+
+  test("uploads a 3D RGB ndarray (3 channels)", () => {
+    const loader = new NDArrayTextureLoader(gl);
+    const arr = ndarray(new Uint8Array([10, 20, 30]), [1, 1, 3]);
+    const result = loader.get(arr);
+    expect(gl.isTexture(result.texture)).toBe(true);
+    loader.dispose();
+  });
+
+  test("rejects unsupported channel counts", () => {
+    const loader = new NDArrayTextureLoader(gl);
+    const arr = ndarray(new Uint8Array(5), [1, 1, 5]);
+    expect(() => loader.get(arr)).toThrow(/Invalid shape for pixel coords/);
+    loader.dispose();
+  });
+
+  test("rejects shapes larger than MAX_TEXTURE_SIZE", () => {
+    const loader = new NDArrayTextureLoader(gl);
+    const max = gl.getParameter(gl.MAX_TEXTURE_SIZE);
+    const arr = ndarray(new Uint8Array(4), [max + 1, 1, 4]);
+    expect(() => loader.get(arr)).toThrow(/Invalid texture size/);
+    loader.dispose();
+  });
+});

--- a/packages/webgltexture-loader-ndarray/src/NDArrayTextureLoader.ts
+++ b/packages/webgltexture-loader-ndarray/src/NDArrayTextureLoader.ts
@@ -1,9 +1,9 @@
+import type { NdArray } from "ndarray";
 import {
-  WebGLTextureLoaderSyncHashCache,
   createTexture,
   globalRegistry,
+  WebGLTextureLoaderSyncHashCache,
 } from "webgltexture-loader";
-import type { NdArray } from "ndarray";
 import drawNDArrayTexture from "./drawNDArrayTexture.js";
 
 export default class NDArrayTextureLoader extends WebGLTextureLoaderSyncHashCache<NdArray> {
@@ -16,7 +16,7 @@ export default class NDArrayTextureLoader extends WebGLTextureLoaderSyncHashCach
 
   override canLoad(input: unknown): boolean {
     const obj = input as { shape?: unknown; data?: unknown; stride?: unknown };
-    return !!(obj && obj.shape && obj.data && obj.stride);
+    return !!(obj?.shape && obj.data && obj.stride);
   }
 
   override inputHash(input: NdArray) {
@@ -28,7 +28,7 @@ export default class NDArrayTextureLoader extends WebGLTextureLoaderSyncHashCach
     const texture = createTexture(gl);
     gl.bindTexture(gl.TEXTURE_2D, texture);
     const [width, height] = input.shape;
-    drawNDArrayTexture(gl, texture, input, this.floatSupported);
+    drawNDArrayTexture(gl, input, this.floatSupported);
     return { texture, width, height };
   }
 
@@ -37,7 +37,7 @@ export default class NDArrayTextureLoader extends WebGLTextureLoaderSyncHashCach
     const result = this.get(input);
     if (!result) return;
     gl.bindTexture(gl.TEXTURE_2D, result.texture);
-    drawNDArrayTexture(gl, result.texture, input, this.floatSupported);
+    drawNDArrayTexture(gl, input, this.floatSupported);
   }
 }
 

--- a/packages/webgltexture-loader-ndarray/src/drawNDArrayTexture.ts
+++ b/packages/webgltexture-loader-ndarray/src/drawNDArrayTexture.ts
@@ -1,5 +1,5 @@
-import ndarray from "ndarray";
 import type { NdArray } from "ndarray";
+import ndarray from "ndarray";
 import ops from "ndarray-ops";
 import pool from "typedarray-pool";
 
@@ -7,21 +7,14 @@ import pool from "typedarray-pool";
 // https://github.com/stackgl/gl-texture2d/blob/master/texture.js
 
 type GlobalWithBuffer = { Buffer?: { isBuffer: (b: unknown) => boolean } };
+// Browser shim so typedarray-pool's Buffer.isBuffer check doesn't crash.
 if (typeof (globalThis as GlobalWithBuffer).Buffer === "undefined") {
-  // Browser shim so typedarray-pool's Buffer.isBuffer check doesn't crash.
-  class BufferShim {
-    static isBuffer = (b: unknown) => b instanceof BufferShim;
-  }
-  (globalThis as GlobalWithBuffer).Buffer = BufferShim;
+  (globalThis as GlobalWithBuffer).Buffer = { isBuffer: () => false };
 }
 
 function isPacked(shape: number[], stride: number[]): boolean {
   if (shape.length === 3) {
-    return (
-      stride[2] === 1 &&
-      stride[1] === shape[0] * shape[2] &&
-      stride[0] === shape[2]
-    );
+    return stride[2] === 1 && stride[1] === shape[0] * shape[2] && stride[0] === shape[2];
   }
   return stride[0] === 1 && stride[1] === shape[0];
 }
@@ -32,23 +25,16 @@ function convertFloatToUint8(out: NdArray, inp: NdArray): void {
 
 export default function drawNDArrayTexture(
   gl: WebGLRenderingContext,
-  texture: WebGLTexture,
   array: NdArray,
-  floatSupported: boolean
+  floatSupported: boolean,
 ): void {
   const isWebGL1 =
-    typeof WebGLRenderingContext === "undefined" ||
-    gl instanceof WebGLRenderingContext;
+    typeof WebGLRenderingContext === "undefined" || gl instanceof WebGLRenderingContext;
 
   let dtype: string = array.dtype;
   let shape = array.shape.slice();
   const maxSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
-  if (
-    shape[0] < 0 ||
-    shape[0] > maxSize ||
-    shape[1] < 0 ||
-    shape[1] > maxSize
-  ) {
+  if (shape[0] < 0 || shape[0] > maxSize || shape[1] < 0 || shape[1] > maxSize) {
     throw new Error("webgltexture-loader-ndarray: Invalid texture size");
   }
   let packed = isPacked(shape, array.stride.slice());
@@ -71,12 +57,7 @@ export default function drawNDArrayTexture(
   if (shape.length === 2) {
     internalformat = format = gl.LUMINANCE;
     shape = [shape[0], shape[1], 1];
-    array = ndarray(
-      array.data,
-      shape,
-      [array.stride[0], array.stride[1], 1],
-      array.offset
-    );
+    array = ndarray(array.data, shape, [array.stride[0], array.stride[1], 1], array.offset);
   } else if (shape.length === 3) {
     if (shape[2] === 1) {
       internalformat = format = gl.ALPHA;
@@ -89,14 +70,10 @@ export default function drawNDArrayTexture(
       if (!isWebGL1) floatSupported = false;
     } else if (shape[2] === 3) {
       format = gl.RGB;
-      internalformat = isWebGL1
-        ? gl.RGB
-        : (gl as unknown as { RGB32F: number }).RGB32F;
+      internalformat = isWebGL1 ? gl.RGB : (gl as unknown as { RGB32F: number }).RGB32F;
     } else if (shape[2] === 4) {
       format = gl.RGBA;
-      internalformat = isWebGL1
-        ? gl.RGBA
-        : (gl as unknown as { RGBA32F: number }).RGBA32F;
+      internalformat = isWebGL1 ? gl.RGBA : (gl as unknown as { RGBA32F: number }).RGBA32F;
     } else {
       throw new Error("webgltexture-loader-ndarray: Invalid shape for pixel coords");
     }
@@ -112,17 +89,12 @@ export default function drawNDArrayTexture(
   let store: Uint8Array | Float32Array | undefined;
   if (!packed) {
     const stride = [shape[2], shape[2] * shape[0], 1];
-    if (
-      (dtype === "float32" || dtype === "float64") &&
-      type === gl.UNSIGNED_BYTE
-    ) {
+    if ((dtype === "float32" || dtype === "float64") && type === gl.UNSIGNED_BYTE) {
       store = pool.malloc(size, "uint8") as Uint8Array;
       const out = ndarray(store, shape, stride, 0);
       convertFloatToUint8(out, array);
     } else {
-      store = pool.malloc(size, dtype as "uint8" | "float32") as
-        | Uint8Array
-        | Float32Array;
+      store = pool.malloc(size, dtype as "uint8" | "float32") as Uint8Array | Float32Array;
       const out = ndarray(store, shape, stride, 0);
       ops.assign(out, array);
     }
@@ -130,22 +102,9 @@ export default function drawNDArrayTexture(
   } else if (array.offset === 0 && array.data.length === size) {
     buffer = array.data as ArrayBufferView;
   } else {
-    buffer = (array.data as Uint8Array).subarray(
-      array.offset,
-      array.offset + size
-    );
+    buffer = (array.data as Uint8Array).subarray(array.offset, array.offset + size);
   }
-  gl.texImage2D(
-    gl.TEXTURE_2D,
-    0,
-    internalformat,
-    shape[0],
-    shape[1],
-    0,
-    format,
-    type,
-    buffer
-  );
+  gl.texImage2D(gl.TEXTURE_2D, 0, internalformat, shape[0], shape[1], 0, format, type, buffer);
   if (store) {
     pool.free(store);
   }

--- a/packages/webgltexture-loader-ndarray/src/integration.gl.test.ts
+++ b/packages/webgltexture-loader-ndarray/src/integration.gl.test.ts
@@ -1,0 +1,45 @@
+import ndarray from "ndarray";
+import { LoaderResolver, LoadersRegistry } from "webgltexture-loader";
+import NDArrayTextureLoader from "./NDArrayTextureLoader.js";
+
+let createGL: ((w: number, h: number) => WebGLRenderingContext) | null = null;
+try {
+  createGL = require("gl");
+} catch {
+  createGL = null;
+}
+
+const describeGL = createGL ? describe : describe.skip;
+
+describeGL("LoaderResolver + NDArrayTextureLoader end-to-end", () => {
+  let gl: WebGLRenderingContext;
+
+  beforeEach(() => {
+    gl = createGL!(2, 2);
+  });
+
+  afterEach(() => {
+    (gl.getExtension("STACKGL_destroy_context") as { destroy(): void } | null)?.destroy();
+  });
+
+  test("resolves an ndarray input and uploads it", () => {
+    const registry = new LoadersRegistry();
+    registry.add(NDArrayTextureLoader);
+    const resolver = new LoaderResolver(gl, registry);
+
+    const arr = ndarray(new Uint8Array([255, 0, 0, 255]), [1, 1, 4]);
+    const loader = resolver.resolve(arr);
+    expect(loader).toBeInstanceOf(NDArrayTextureLoader);
+
+    const result = loader!.get(arr);
+    expect(result?.width).toBe(1);
+    expect(result?.height).toBe(1);
+    expect(gl.isTexture(result!.texture)).toBe(true);
+
+    expect(resolver.resolve(42)).toBeUndefined();
+    expect(resolver.resolve("foo")).toBeUndefined();
+
+    resolver.dispose();
+    expect(gl.isTexture(result!.texture)).toBe(false);
+  });
+});

--- a/packages/webgltexture-loader-react-native-config/package.json
+++ b/packages/webgltexture-loader-react-native-config/package.json
@@ -2,19 +2,20 @@
   "name": "webgltexture-loader-react-native-config",
   "version": "2.0.0",
   "description": "load any react-native-webgl 'config' object for webgltexture-loader",
-  "main": "lib/ConfigTextureLoader.js",
+  "license": "MIT",
+  "author": "Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>",
+  "repository": "https://github.com/gre/webgltexture-loader",
   "files": [
     "src",
     "lib"
   ],
-  "repository": "https://github.com/gre/webgltexture-loader",
-  "author": "Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>",
-  "license": "MIT",
-  "dependencies": {
-    "webgltexture-loader": "^2.0.0"
-  },
+  "main": "lib/ConfigTextureLoader.js",
   "types": "lib/ConfigTextureLoader.d.ts",
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "webgltexture-loader": "^2.0.0"
   }
 }

--- a/packages/webgltexture-loader-react-native-config/src/ConfigTextureLoader.ts
+++ b/packages/webgltexture-loader-react-native-config/src/ConfigTextureLoader.ts
@@ -1,7 +1,7 @@
 import {
   globalRegistry,
-  WebGLTextureLoaderAsyncHashCache,
   type TextureAndSize,
+  WebGLTextureLoaderAsyncHashCache,
 } from "webgltexture-loader";
 
 type Config = Record<string, unknown>;
@@ -18,9 +18,7 @@ interface RNGLExtension {
 export default class ConfigTextureLoader extends WebGLTextureLoaderAsyncHashCache<Config> {
   static priority = -100;
 
-  rngl: RNGLExtension | null = this.gl.getExtension(
-    "RN"
-  ) as unknown as RNGLExtension | null;
+  rngl: RNGLExtension | null = this.gl.getExtension("RN") as unknown as RNGLExtension | null;
 
   override canLoad(input: unknown): boolean {
     return !!this.rngl && typeof input === "object" && input !== null;

--- a/packages/webgltexture-loader-react-native-imagesource/package.json
+++ b/packages/webgltexture-loader-react-native-imagesource/package.json
@@ -2,19 +2,20 @@
   "name": "webgltexture-loader-react-native-imagesource",
   "version": "2.0.0",
   "description": "load a React Native ImageSource for react-native-webgl & webgltexture-loader",
-  "main": "lib/ImageSourceTextureLoader.js",
+  "license": "MIT",
+  "author": "Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>",
+  "repository": "https://github.com/gre/webgltexture-loader",
   "files": [
     "src",
     "lib"
   ],
-  "repository": "https://github.com/gre/webgltexture-loader",
-  "author": "Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>",
-  "license": "MIT",
-  "dependencies": {
-    "webgltexture-loader": "^2.0.0"
-  },
+  "main": "lib/ImageSourceTextureLoader.js",
   "types": "lib/ImageSourceTextureLoader.d.ts",
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "webgltexture-loader": "^2.0.0"
   }
 }

--- a/packages/webgltexture-loader-react-native-imagesource/src/ImageSourceTextureLoader.ts
+++ b/packages/webgltexture-loader-react-native-imagesource/src/ImageSourceTextureLoader.ts
@@ -1,7 +1,7 @@
 import {
   globalRegistry,
-  WebGLTextureLoaderAsyncHashCache,
   type TextureAndSize,
+  WebGLTextureLoaderAsyncHashCache,
 } from "webgltexture-loader";
 
 type ImageSource = number | { uri: string };
@@ -12,9 +12,7 @@ interface RNGLExtension {
 }
 
 export default class ImageSourceTextureLoader extends WebGLTextureLoaderAsyncHashCache<ImageSource> {
-  rngl: RNGLExtension | null = this.gl.getExtension(
-    "RN"
-  ) as unknown as RNGLExtension | null;
+  rngl: RNGLExtension | null = this.gl.getExtension("RN") as unknown as RNGLExtension | null;
 
   override canLoad(input: unknown): boolean {
     if (!this.rngl) return false;

--- a/packages/webgltexture-loader-react-native/package.json
+++ b/packages/webgltexture-loader-react-native/package.json
@@ -2,20 +2,21 @@
   "name": "webgltexture-loader-react-native",
   "version": "2.0.0",
   "description": "collection of webgltexture-loader in react-native-webgl implementation context",
-  "main": "lib/index.js",
+  "license": "MIT",
+  "author": "Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>",
+  "repository": "https://github.com/gre/webgltexture-loader",
   "files": [
     "src",
     "lib"
   ],
-  "repository": "https://github.com/gre/webgltexture-loader",
-  "author": "Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>",
-  "license": "MIT",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
   "dependencies": {
     "webgltexture-loader-react-native-config": "^2.0.0",
     "webgltexture-loader-react-native-imagesource": "^2.0.0"
-  },
-  "types": "lib/index.d.ts",
-  "scripts": {
-    "build": "tsc"
   }
 }

--- a/packages/webgltexture-loader/package.json
+++ b/packages/webgltexture-loader/package.json
@@ -3,21 +3,22 @@
   "version": "2.0.0",
   "description": "load & cache various kind of WebGLTexture with an extensible and loosely coupled system",
   "keywords": [
-    "webgl",
     "gl",
-    "webgltexture",
-    "loader"
+    "loader",
+    "webgl",
+    "webgltexture"
   ],
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "license": "MIT",
+  "author": "Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>",
+  "repository": "https://github.com/gre/webgltexture-loader",
   "files": [
     "src",
     "lib"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
-    "build": "tsc"
-  },
-  "repository": "https://github.com/gre/webgltexture-loader",
-  "author": "Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>",
-  "license": "MIT"
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  }
 }

--- a/packages/webgltexture-loader/src/LoaderResolver.test.ts
+++ b/packages/webgltexture-loader/src/LoaderResolver.test.ts
@@ -2,41 +2,87 @@ import LoaderResolver from "./LoaderResolver.js";
 import LoadersRegistry from "./LoadersRegistry.js";
 import WebGLTextureLoaderSyncHashCache from "./WebGLTextureLoaderSyncHashCache.js";
 
+const mockGL = () => ({ deleteTexture: () => {} }) as unknown as WebGLRenderingContext;
+
+class NumberLoader extends WebGLTextureLoaderSyncHashCache<number> {
+  override canLoad(input: unknown) {
+    return typeof input === "number";
+  }
+  override inputHash(input: number) {
+    return input;
+  }
+  override getNoCache(input: number) {
+    return {
+      texture: { id: input } as unknown as WebGLTexture,
+      width: 2,
+      height: 2,
+    };
+  }
+}
+
+class StringLoader extends WebGLTextureLoaderSyncHashCache<string> {
+  static priority = 100;
+  override canLoad(input: unknown) {
+    return typeof input === "string";
+  }
+  override inputHash(input: string) {
+    return input;
+  }
+  override getNoCache(input: string) {
+    return {
+      texture: { id: input } as unknown as WebGLTexture,
+      width: 1,
+      height: 1,
+    };
+  }
+}
+
 test("an empty LoaderResolver resolves nothing", () => {
   const gl = {} as WebGLRenderingContext;
-  const resolver = new LoaderResolver(gl);
+  // Pass an explicit empty registry so this test doesn't pick up loaders
+  // that other test files have side-effect-registered into globalRegistry.
+  const resolver = new LoaderResolver(gl, new LoadersRegistry());
   expect(resolver.resolve(null)).toBeUndefined();
   expect(resolver.resolve(42)).toBeUndefined();
   expect(resolver.resolve("foo")).toBeUndefined();
   resolver.dispose();
 });
 
-test("LoaderResolver works with one loader", () => {
-  const gl = {
-    deleteTexture: () => {},
-  } as unknown as WebGLRenderingContext;
+test("resolves the matching loader and rejects unsupported inputs", () => {
   const registry = new LoadersRegistry();
-  class FakeLoader extends WebGLTextureLoaderSyncHashCache<number> {
-    canLoad(input: unknown) {
-      return typeof input === "number";
-    }
-    inputHash(input: number) {
-      return input;
-    }
-    getNoCache(input: number) {
-      return {
-        texture: { id: input } as unknown as WebGLTexture,
-        width: 2,
-        height: 2,
-      };
-    }
-  }
-  registry.add(FakeLoader);
-  const resolver = new LoaderResolver(gl, registry);
+  registry.add(NumberLoader);
+  const resolver = new LoaderResolver(mockGL(), registry);
   expect(resolver.resolve(null)).toBeUndefined();
   expect(resolver.resolve("foo")).toBeUndefined();
-  const loader = resolver.resolve(42);
-  expect(loader).toBeDefined();
-  expect(loader).toBeInstanceOf(FakeLoader);
+  expect(resolver.resolve(42)).toBeInstanceOf(NumberLoader);
   resolver.dispose();
+});
+
+test("higher-priority loader wins when multiple registered", () => {
+  const registry = new LoadersRegistry();
+  registry.add(NumberLoader);
+  registry.add(StringLoader);
+  const resolver = new LoaderResolver(mockGL(), registry);
+  expect(resolver.resolve("foo")).toBeInstanceOf(StringLoader);
+  expect(resolver.resolve(42)).toBeInstanceOf(NumberLoader);
+});
+
+test("dispose() cascades to every loader", () => {
+  const calls: string[] = [];
+  class TrackingA extends WebGLTextureLoaderSyncHashCache<number> {
+    override dispose() {
+      calls.push("A");
+    }
+  }
+  class TrackingB extends WebGLTextureLoaderSyncHashCache<number> {
+    override dispose() {
+      calls.push("B");
+    }
+  }
+  const registry = new LoadersRegistry();
+  registry.add(TrackingA);
+  registry.add(TrackingB);
+  const resolver = new LoaderResolver(mockGL(), registry);
+  resolver.dispose();
+  expect(calls.toSorted()).toEqual(["A", "B"]);
 });

--- a/packages/webgltexture-loader/src/LoaderResolver.ts
+++ b/packages/webgltexture-loader/src/LoaderResolver.ts
@@ -1,19 +1,16 @@
+import globalRegistry from "./globalRegistry.js";
 import type LoadersRegistry from "./LoadersRegistry.js";
 import type WebGLTextureLoader from "./WebGLTextureLoader.js";
-import globalRegistry from "./globalRegistry.js";
 
 export default class LoaderResolver {
   loaders: WebGLTextureLoader<unknown>[];
 
-  constructor(
-    gl: WebGLRenderingContext,
-    registry: LoadersRegistry = globalRegistry
-  ) {
+  constructor(gl: WebGLRenderingContext, registry: LoadersRegistry = globalRegistry) {
     this.loaders = registry.get().map((L) => new L(gl));
   }
 
   dispose(): void {
-    this.loaders.forEach((l) => l.dispose());
+    for (const l of this.loaders) l.dispose();
   }
 
   resolve<T>(input: T): WebGLTextureLoader<T> | undefined {

--- a/packages/webgltexture-loader/src/LoadersRegistry.test.ts
+++ b/packages/webgltexture-loader/src/LoadersRegistry.test.ts
@@ -1,0 +1,42 @@
+import LoadersRegistry from "./LoadersRegistry.js";
+import WebGLTextureLoader from "./WebGLTextureLoader.js";
+
+class A extends WebGLTextureLoader<unknown> {}
+class B extends WebGLTextureLoader<unknown> {}
+class C extends WebGLTextureLoader<unknown> {
+  static priority = 10;
+}
+class D extends WebGLTextureLoader<unknown> {
+  static priority = -5;
+}
+
+test("empty registry returns []", () => {
+  const r = new LoadersRegistry();
+  expect(r.get()).toEqual([]);
+});
+
+test("add appends loader classes", () => {
+  const r = new LoadersRegistry();
+  r.add(A);
+  r.add(B);
+  expect(r.get()).toEqual([A, B]);
+});
+
+test("higher static priority comes first; default priority is 0", () => {
+  const r = new LoadersRegistry();
+  r.add(A);
+  r.add(D);
+  r.add(C);
+  r.add(B);
+  expect(r.get()).toEqual([C, A, B, D]);
+});
+
+test("remove takes a class out and is a no-op for unknown classes", () => {
+  const r = new LoadersRegistry();
+  r.add(A);
+  r.add(B);
+  r.remove(A);
+  expect(r.get()).toEqual([B]);
+  r.remove(C);
+  expect(r.get()).toEqual([B]);
+});

--- a/packages/webgltexture-loader/src/LoadersRegistry.ts
+++ b/packages/webgltexture-loader/src/LoadersRegistry.ts
@@ -1,8 +1,6 @@
 import type WebGLTextureLoader from "./WebGLTextureLoader.js";
 
-export type LoaderClass = new (
-  gl: WebGLRenderingContext
-) => WebGLTextureLoader<unknown>;
+export type LoaderClass = new (gl: WebGLRenderingContext) => WebGLTextureLoader<unknown>;
 
 /**
  * Loaders may declare a static `priority` number; higher priority is
@@ -12,23 +10,17 @@ export default class LoadersRegistry {
   private _loaders: LoaderClass[] = [];
 
   /** Add a TextureLoader class to extend texture format support. */
-  add<T>(
-    loader: new (gl: WebGLRenderingContext) => WebGLTextureLoader<T>
-  ): void {
+  add<T>(loader: new (gl: WebGLRenderingContext) => WebGLTextureLoader<T>): void {
     this._loaders.push(loader as LoaderClass);
     this._loaders.sort((a, b) => {
       const ap = (a as { priority?: number }).priority;
       const bp = (b as { priority?: number }).priority;
-      return (
-        (typeof bp === "number" ? bp : 0) - (typeof ap === "number" ? ap : 0)
-      );
+      return (typeof bp === "number" ? bp : 0) - (typeof ap === "number" ? ap : 0);
     });
   }
 
   /** Remove a previously added WebGLTextureLoader class. */
-  remove<T>(
-    loader: new (gl: WebGLRenderingContext) => WebGLTextureLoader<T>
-  ): void {
+  remove<T>(loader: new (gl: WebGLRenderingContext) => WebGLTextureLoader<T>): void {
     const i = this._loaders.indexOf(loader as LoaderClass);
     if (i !== -1) {
       this._loaders.splice(i, 1);

--- a/packages/webgltexture-loader/src/WebGLTextureLoaderAsyncHashCache.test.ts
+++ b/packages/webgltexture-loader/src/WebGLTextureLoaderAsyncHashCache.test.ts
@@ -1,34 +1,145 @@
 import WebGLTextureLoaderAsyncHashCache from "./WebGLTextureLoaderAsyncHashCache.js";
 
-test("WebGLTextureLoaderAsyncHashCache simple usage", async () => {
-  const gl = {
-    deleteTexture: () => {},
-  } as unknown as WebGLRenderingContext;
-  class FakeLoader extends WebGLTextureLoaderAsyncHashCache<number> {
-    canLoad(input: unknown) {
+const mockGL = (deleted: WebGLTexture[] = []) =>
+  ({
+    deleteTexture: (t: WebGLTexture) => {
+      deleted.push(t);
+    },
+  }) as unknown as WebGLRenderingContext;
+
+class FakeLoader extends WebGLTextureLoaderAsyncHashCache<number> {
+  loadNoCacheCalls = 0;
+  override canLoad(input: unknown) {
+    return typeof input === "number";
+  }
+  override inputHash(input: number) {
+    return input;
+  }
+  override loadNoCache(input: number) {
+    this.loadNoCacheCalls++;
+    return {
+      promise: Promise.resolve({
+        texture: { id: input } as unknown as WebGLTexture,
+        width: 2,
+        height: 2,
+      }),
+      dispose: () => {},
+    };
+  }
+}
+
+test("load resolves and get returns the same value afterwards", async () => {
+  const loader = new FakeLoader(mockGL());
+  const res = await loader.load(42);
+  expect(res).toMatchObject({ width: 2, height: 2 });
+  expect(loader.get(42)).toBe(res);
+  expect(loader.get(43)).toBeUndefined();
+  loader.dispose();
+});
+
+test("load is idempotent: same input returns the exact same Promise", () => {
+  const loader = new FakeLoader(mockGL());
+  const p1 = loader.load(42);
+  const p2 = loader.load(42);
+  expect(p1).toBe(p2);
+  expect(loader.loadNoCacheCalls).toBe(1);
+  loader.dispose();
+});
+
+test("cancelLoad invokes the underlying dispose and clears the promise", () => {
+  let underlyingDisposed = false;
+  class CancelableLoader extends WebGLTextureLoaderAsyncHashCache<number> {
+    override canLoad(input: unknown) {
       return typeof input === "number";
     }
-    inputHash(input: number) {
+    override inputHash(input: number) {
       return input;
     }
-    loadNoCache(input: number) {
+    override loadNoCache(_input: number) {
       return {
-        promise: Promise.resolve({
-          texture: { id: input } as unknown as WebGLTexture,
-          width: 2,
-          height: 2,
+        promise: new Promise<{
+          texture: WebGLTexture;
+          width: number;
+          height: number;
+        }>(() => {}),
+        dispose: () => {
+          underlyingDisposed = true;
+        },
+      };
+    }
+  }
+  const loader = new CancelableLoader(mockGL());
+  loader.load(42);
+  loader.cancelLoad(42);
+  expect(underlyingDisposed).toBe(true);
+  // After cancel, a fresh load() must call loadNoCache again.
+  underlyingDisposed = false;
+  loader.load(42);
+  expect(underlyingDisposed).toBe(false);
+});
+
+test("dispose during pending load: pending load resolves but result is dropped", async () => {
+  let resolveLoad!: (v: { texture: WebGLTexture; width: number; height: number }) => void;
+  class SlowLoader extends WebGLTextureLoaderAsyncHashCache<number> {
+    override canLoad(input: unknown) {
+      return typeof input === "number";
+    }
+    override inputHash(input: number) {
+      return input;
+    }
+    override loadNoCache(_input: number) {
+      return {
+        promise: new Promise<{
+          texture: WebGLTexture;
+          width: number;
+          height: number;
+        }>((r) => {
+          resolveLoad = r;
         }),
         dispose: () => {},
       };
     }
   }
-  const loader = new FakeLoader(gl);
-  let res = await loader.load(42);
-  expect(res).toMatchObject({ width: 2, height: 2 });
-  expect(loader.get(42)).toBe(res);
-  expect(loader.get(43)).toBeUndefined();
-  res = await loader.load(43);
-  expect(res).toMatchObject({ width: 2, height: 2 });
-  expect(loader.get(43)).toBe(res);
+  const loader = new SlowLoader(mockGL());
+  const p = loader.load(42);
   loader.dispose();
+  resolveLoad({
+    texture: {} as WebGLTexture,
+    width: 1,
+    height: 1,
+  });
+  // The promise should never resolve (dispose drops the result).
+  const winner = await Promise.race([
+    p.then(() => "resolved"),
+    new Promise((r) => setTimeout(r, 10, "timeout")),
+  ]);
+  expect(winner).toBe("timeout");
+});
+
+test("dispose deletes every cached texture exactly once", async () => {
+  const deleted: WebGLTexture[] = [];
+  const loader = new FakeLoader(mockGL(deleted));
+  const a = await loader.load(1);
+  const b = await loader.load(2);
+  loader.dispose();
+  expect(deleted).toEqual([a.texture, b.texture]);
+});
+
+test("loadNoCache rejection propagates", async () => {
+  class FailingLoader extends WebGLTextureLoaderAsyncHashCache<number> {
+    override canLoad(input: unknown) {
+      return typeof input === "number";
+    }
+    override inputHash(input: number) {
+      return input;
+    }
+    override loadNoCache(_input: number) {
+      return {
+        promise: Promise.reject(new Error("boom")),
+        dispose: () => {},
+      };
+    }
+  }
+  const loader = new FailingLoader(mockGL());
+  await expect(loader.load(42)).rejects.toThrow(/boom/);
 });

--- a/packages/webgltexture-loader/src/WebGLTextureLoaderAsyncHashCache.ts
+++ b/packages/webgltexture-loader/src/WebGLTextureLoaderAsyncHashCache.ts
@@ -2,9 +2,7 @@ import WebGLTextureLoader, { type TextureAndSize } from "./WebGLTextureLoader.js
 
 const neverEnding: Promise<never> = new Promise(() => {});
 
-export default class WebGLTextureLoaderAsyncHashCache<
-  T
-> extends WebGLTextureLoader<T> {
+export default class WebGLTextureLoaderAsyncHashCache<T> extends WebGLTextureLoader<T> {
   inputHash(_input: T): unknown {
     return "";
   }
@@ -28,10 +26,8 @@ export default class WebGLTextureLoaderAsyncHashCache<
 
   override dispose(): void {
     const { promises, results, inputs, disposes } = this;
-    disposes.forEach((d) => d());
-    results.forEach((result) => {
-      this.disposeTexture(result.texture);
-    });
+    for (const d of disposes.values()) d();
+    for (const result of results.values()) this.disposeTexture(result.texture);
     promises.clear();
     results.clear();
     inputs.clear();

--- a/packages/webgltexture-loader/src/WebGLTextureLoaderSyncHashCache.test.ts
+++ b/packages/webgltexture-loader/src/WebGLTextureLoaderSyncHashCache.test.ts
@@ -1,26 +1,52 @@
 import WebGLTextureLoaderSyncHashCache from "./WebGLTextureLoaderSyncHashCache.js";
 
-test("simple usage", () => {
-  const gl = {
-    deleteTexture: () => {},
-  } as unknown as WebGLRenderingContext;
-  class FakeLoader extends WebGLTextureLoaderSyncHashCache<number> {
-    canLoad(input: unknown) {
-      return typeof input === "number";
-    }
-    inputHash(input: number) {
-      return input;
-    }
-    getNoCache(input: number) {
-      return {
-        texture: { id: input } as unknown as WebGLTexture,
-        width: 2,
-        height: 2,
-      };
-    }
+const mockGL = (deleted: WebGLTexture[] = []) =>
+  ({
+    deleteTexture: (t: WebGLTexture) => {
+      deleted.push(t);
+    },
+  }) as unknown as WebGLRenderingContext;
+
+class CountingLoader extends WebGLTextureLoaderSyncHashCache<number> {
+  getNoCacheCalls = 0;
+  override canLoad(input: unknown) {
+    return typeof input === "number";
   }
-  const loader = new FakeLoader(gl);
-  expect(loader.get(42)).toMatchObject({ width: 2, height: 2 });
-  expect(loader.get(43)).toMatchObject({ width: 2, height: 2 });
+  override inputHash(input: number) {
+    return input;
+  }
+  override getNoCache(input: number) {
+    this.getNoCacheCalls++;
+    return {
+      texture: { id: input } as unknown as WebGLTexture,
+      width: 2,
+      height: 2,
+    };
+  }
+}
+
+test("get caches: subsequent calls with the same input return the same value", () => {
+  const loader = new CountingLoader(mockGL());
+  const a = loader.get(42);
+  const b = loader.get(42);
+  expect(a).toBe(b);
+  expect(loader.getNoCacheCalls).toBe(1);
   loader.dispose();
+});
+
+test("load() resolves to the same value as get() and is idempotent", async () => {
+  const loader = new CountingLoader(mockGL());
+  const p1 = loader.load(42);
+  const p2 = loader.load(42);
+  expect(p1).toBe(p2);
+  await expect(p1).resolves.toBe(loader.get(42));
+});
+
+test("dispose deletes every cached texture", () => {
+  const deleted: WebGLTexture[] = [];
+  const loader = new CountingLoader(mockGL(deleted));
+  const a = loader.get(1);
+  const b = loader.get(2);
+  loader.dispose();
+  expect(deleted).toEqual([a.texture, b.texture]);
 });

--- a/packages/webgltexture-loader/src/WebGLTextureLoaderSyncHashCache.ts
+++ b/packages/webgltexture-loader/src/WebGLTextureLoaderSyncHashCache.ts
@@ -1,8 +1,6 @@
 import WebGLTextureLoader, { type TextureAndSize } from "./WebGLTextureLoader.js";
 
-export default class WebGLTextureLoaderSyncHashCache<
-  T
-> extends WebGLTextureLoader<T> {
+export default class WebGLTextureLoaderSyncHashCache<T> extends WebGLTextureLoader<T> {
   inputHash(_input: T): unknown {
     return "";
   }

--- a/packages/webgltexture-loader/src/createTexture.gl.test.ts
+++ b/packages/webgltexture-loader/src/createTexture.gl.test.ts
@@ -1,0 +1,34 @@
+import { createTexture } from "./WebGLTextureLoader.js";
+
+let createGL: ((w: number, h: number) => WebGLRenderingContext) | null = null;
+try {
+  // headless-gl is optional locally (compiled native binding may be missing).
+  // CI installs it, so the tests run there.
+  createGL = require("gl");
+} catch {
+  createGL = null;
+}
+
+const describeGL = createGL ? describe : describe.skip;
+
+describeGL("createTexture against headless-gl", () => {
+  let gl: WebGLRenderingContext;
+
+  beforeEach(() => {
+    gl = createGL!(2, 2);
+  });
+
+  afterEach(() => {
+    (gl.getExtension("STACKGL_destroy_context") as { destroy(): void } | null)?.destroy();
+  });
+
+  test("returns a real WebGLTexture", () => {
+    const tex = createTexture(gl);
+    expect(tex).toBeTruthy();
+    // WebGL: isTexture returns true only after the texture has been bound.
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    expect(gl.isTexture(tex)).toBe(true);
+    gl.deleteTexture(tex);
+    expect(gl.isTexture(tex)).toBe(false);
+  });
+});

--- a/packages/webgltexture-loader/src/globalRegistry.ts
+++ b/packages/webgltexture-loader/src/globalRegistry.ts
@@ -1,10 +1,9 @@
 import LoadersRegistry from "./LoadersRegistry.js";
 
-const root = globalThis as unknown as Record<
-  string,
-  LoadersRegistry | undefined
->;
+const root = globalThis as unknown as Record<string, LoadersRegistry | undefined>;
 const KEY = "__webglTextureLoader_registry";
 
 // Singleton on globalThis so multiple bundled copies of this lib share one registry.
-export default (root[KEY] ??= new LoadersRegistry());
+const ensureRegistry = (): LoadersRegistry => (root[KEY] ??= new LoadersRegistry());
+
+export default ensureRegistry();

--- a/packages/webgltexture-loader/src/index.ts
+++ b/packages/webgltexture-loader/src/index.ts
@@ -1,21 +1,17 @@
-import WebGLTextureLoader, {
-  createTexture,
-  type TextureAndSize,
-} from "./WebGLTextureLoader.js";
+import globalRegistry from "./globalRegistry.js";
+import LoaderResolver from "./LoaderResolver.js";
+import LoadersRegistry from "./LoadersRegistry.js";
+import WebGLTextureLoader, { createTexture, type TextureAndSize } from "./WebGLTextureLoader.js";
 import WebGLTextureLoaderAsyncHashCache from "./WebGLTextureLoaderAsyncHashCache.js";
 import WebGLTextureLoaderSyncHashCache from "./WebGLTextureLoaderSyncHashCache.js";
-import LoadersRegistry from "./LoadersRegistry.js";
-import LoaderResolver from "./LoaderResolver.js";
-import globalRegistry from "./globalRegistry.js";
 
+export type { TextureAndSize };
 export {
   createTexture,
   globalRegistry,
-  LoadersRegistry,
   LoaderResolver,
+  LoadersRegistry,
   WebGLTextureLoader,
   WebGLTextureLoaderAsyncHashCache,
   WebGLTextureLoaderSyncHashCache,
 };
-
-export type { TextureAndSize };

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "lib": ["ES2022", "DOM"],
+    "lib": ["ES2023", "DOM"],
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1139,6 +1139,272 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxfmt/binding-android-arm-eabi@npm:0.47.0":
+  version: 0.47.0
+  resolution: "@oxfmt/binding-android-arm-eabi@npm:0.47.0"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-android-arm64@npm:0.47.0":
+  version: 0.47.0
+  resolution: "@oxfmt/binding-android-arm64@npm:0.47.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-darwin-arm64@npm:0.47.0":
+  version: 0.47.0
+  resolution: "@oxfmt/binding-darwin-arm64@npm:0.47.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-darwin-x64@npm:0.47.0":
+  version: 0.47.0
+  resolution: "@oxfmt/binding-darwin-x64@npm:0.47.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-freebsd-x64@npm:0.47.0":
+  version: 0.47.0
+  resolution: "@oxfmt/binding-freebsd-x64@npm:0.47.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-linux-arm-gnueabihf@npm:0.47.0":
+  version: 0.47.0
+  resolution: "@oxfmt/binding-linux-arm-gnueabihf@npm:0.47.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-linux-arm-musleabihf@npm:0.47.0":
+  version: 0.47.0
+  resolution: "@oxfmt/binding-linux-arm-musleabihf@npm:0.47.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-linux-arm64-gnu@npm:0.47.0":
+  version: 0.47.0
+  resolution: "@oxfmt/binding-linux-arm64-gnu@npm:0.47.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-linux-arm64-musl@npm:0.47.0":
+  version: 0.47.0
+  resolution: "@oxfmt/binding-linux-arm64-musl@npm:0.47.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-linux-ppc64-gnu@npm:0.47.0":
+  version: 0.47.0
+  resolution: "@oxfmt/binding-linux-ppc64-gnu@npm:0.47.0"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-linux-riscv64-gnu@npm:0.47.0":
+  version: 0.47.0
+  resolution: "@oxfmt/binding-linux-riscv64-gnu@npm:0.47.0"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-linux-riscv64-musl@npm:0.47.0":
+  version: 0.47.0
+  resolution: "@oxfmt/binding-linux-riscv64-musl@npm:0.47.0"
+  conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-linux-s390x-gnu@npm:0.47.0":
+  version: 0.47.0
+  resolution: "@oxfmt/binding-linux-s390x-gnu@npm:0.47.0"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-linux-x64-gnu@npm:0.47.0":
+  version: 0.47.0
+  resolution: "@oxfmt/binding-linux-x64-gnu@npm:0.47.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-linux-x64-musl@npm:0.47.0":
+  version: 0.47.0
+  resolution: "@oxfmt/binding-linux-x64-musl@npm:0.47.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-openharmony-arm64@npm:0.47.0":
+  version: 0.47.0
+  resolution: "@oxfmt/binding-openharmony-arm64@npm:0.47.0"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-win32-arm64-msvc@npm:0.47.0":
+  version: 0.47.0
+  resolution: "@oxfmt/binding-win32-arm64-msvc@npm:0.47.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-win32-ia32-msvc@npm:0.47.0":
+  version: 0.47.0
+  resolution: "@oxfmt/binding-win32-ia32-msvc@npm:0.47.0"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-win32-x64-msvc@npm:0.47.0":
+  version: 0.47.0
+  resolution: "@oxfmt/binding-win32-x64-msvc@npm:0.47.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-android-arm-eabi@npm:1.62.0":
+  version: 1.62.0
+  resolution: "@oxlint/binding-android-arm-eabi@npm:1.62.0"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-android-arm64@npm:1.62.0":
+  version: 1.62.0
+  resolution: "@oxlint/binding-android-arm64@npm:1.62.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-darwin-arm64@npm:1.62.0":
+  version: 1.62.0
+  resolution: "@oxlint/binding-darwin-arm64@npm:1.62.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-darwin-x64@npm:1.62.0":
+  version: 1.62.0
+  resolution: "@oxlint/binding-darwin-x64@npm:1.62.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-freebsd-x64@npm:1.62.0":
+  version: 1.62.0
+  resolution: "@oxlint/binding-freebsd-x64@npm:1.62.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-linux-arm-gnueabihf@npm:1.62.0":
+  version: 1.62.0
+  resolution: "@oxlint/binding-linux-arm-gnueabihf@npm:1.62.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-linux-arm-musleabihf@npm:1.62.0":
+  version: 1.62.0
+  resolution: "@oxlint/binding-linux-arm-musleabihf@npm:1.62.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-linux-arm64-gnu@npm:1.62.0":
+  version: 1.62.0
+  resolution: "@oxlint/binding-linux-arm64-gnu@npm:1.62.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-linux-arm64-musl@npm:1.62.0":
+  version: 1.62.0
+  resolution: "@oxlint/binding-linux-arm64-musl@npm:1.62.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-linux-ppc64-gnu@npm:1.62.0":
+  version: 1.62.0
+  resolution: "@oxlint/binding-linux-ppc64-gnu@npm:1.62.0"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-linux-riscv64-gnu@npm:1.62.0":
+  version: 1.62.0
+  resolution: "@oxlint/binding-linux-riscv64-gnu@npm:1.62.0"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-linux-riscv64-musl@npm:1.62.0":
+  version: 1.62.0
+  resolution: "@oxlint/binding-linux-riscv64-musl@npm:1.62.0"
+  conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-linux-s390x-gnu@npm:1.62.0":
+  version: 1.62.0
+  resolution: "@oxlint/binding-linux-s390x-gnu@npm:1.62.0"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-linux-x64-gnu@npm:1.62.0":
+  version: 1.62.0
+  resolution: "@oxlint/binding-linux-x64-gnu@npm:1.62.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-linux-x64-musl@npm:1.62.0":
+  version: 1.62.0
+  resolution: "@oxlint/binding-linux-x64-musl@npm:1.62.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-openharmony-arm64@npm:1.62.0":
+  version: 1.62.0
+  resolution: "@oxlint/binding-openharmony-arm64@npm:1.62.0"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-win32-arm64-msvc@npm:1.62.0":
+  version: 1.62.0
+  resolution: "@oxlint/binding-win32-arm64-msvc@npm:1.62.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-win32-ia32-msvc@npm:1.62.0":
+  version: 1.62.0
+  resolution: "@oxlint/binding-win32-ia32-msvc@npm:1.62.0"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@oxlint/binding-win32-x64-msvc@npm:1.62.0":
+  version: 1.62.0
+  resolution: "@oxlint/binding-win32-x64-msvc@npm:1.62.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@pkgjs/parseargs@npm:^0.11.0":
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
@@ -1650,6 +1916,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"base64-js@npm:^1.3.1":
+  version: 1.5.1
+  resolution: "base64-js@npm:1.5.1"
+  checksum: 10c0/f23823513b63173a001030fae4f2dabe283b99a9d324ade3ad3d148e218134676f1ee8568c877cd79ec1c53158dcf2d2ba527a97c606618928ba99dd930102bf
+  languageName: node
+  linkType: hard
+
 "baseline-browser-mapping@npm:^2.10.12":
   version: 2.10.24
   resolution: "baseline-browser-mapping@npm:2.10.24"
@@ -1668,10 +1941,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bit-twiddle@npm:^1.0.0":
+"bindings@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "bindings@npm:1.5.0"
+  dependencies:
+    file-uri-to-path: "npm:1.0.0"
+  checksum: 10c0/3dab2491b4bb24124252a91e656803eac24292473e56554e35bbfe3cc1875332cfa77600c3bac7564049dc95075bf6fcc63a4609920ff2d64d0fe405fcf0d4ba
+  languageName: node
+  linkType: hard
+
+"bit-twiddle@npm:^1.0.0, bit-twiddle@npm:^1.0.2":
   version: 1.0.2
   resolution: "bit-twiddle@npm:1.0.2"
   checksum: 10c0/edd86fdaeb27fb5acb9dbde247a71e511ebb6c5406ed645038974203dce8c87ef0359f5d5b60212c2a54d0a52ab16a27c4cc3b1cd4e06256a33881ed77f03d7a
+  languageName: node
+  linkType: hard
+
+"bl@npm:^4.0.3":
+  version: 4.1.0
+  resolution: "bl@npm:4.1.0"
+  dependencies:
+    buffer: "npm:^5.5.0"
+    inherits: "npm:^2.0.4"
+    readable-stream: "npm:^3.4.0"
+  checksum: 10c0/02847e1d2cb089c9dc6958add42e3cdeaf07d13f575973963335ac0fdece563a50ac770ac4c8fa06492d2dd276f6cc3b7f08c7cd9c7a7ad0f8d388b2a28def5f
   languageName: node
   linkType: hard
 
@@ -1743,6 +2036,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buffer@npm:^5.5.0":
+  version: 5.7.1
+  resolution: "buffer@npm:5.7.1"
+  dependencies:
+    base64-js: "npm:^1.3.1"
+    ieee754: "npm:^1.1.13"
+  checksum: 10c0/27cac81cff434ed2876058d72e7c4789d11ff1120ef32c9de48f59eab58179b66710c488987d295ae89a228f835fc66d088652dffeb8e3ba8659f80eb091d55e
+  languageName: node
+  linkType: hard
+
 "callsites@npm:^3.1.0":
   version: 3.1.0
   resolution: "callsites@npm:3.1.0"
@@ -1803,6 +2106,13 @@ __metadata:
   version: 2.1.1
   resolution: "chardet@npm:2.1.1"
   checksum: 10c0/d8391dd412338442b3de0d3a488aa9327f8bcf74b62b8723d6bd0b85c4084d50b731320e0a7c710edb1d44de75969995d2784b80e4c13b004a6c7a0db4c6e793
+  languageName: node
+  linkType: hard
+
+"chownr@npm:^1.1.1":
+  version: 1.1.4
+  resolution: "chownr@npm:1.1.4"
+  checksum: 10c0/ed57952a84cc0c802af900cf7136de643d3aba2eecb59d29344bc2f3f9bf703a301b9d84cdc71f82c3ffc9ccde831b0d92f5b45f91727d6c9da62f23aef9d9db
   languageName: node
   linkType: hard
 
@@ -1898,6 +2208,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"core-util-is@npm:~1.0.0":
+  version: 1.0.3
+  resolution: "core-util-is@npm:1.0.3"
+  checksum: 10c0/90a0e40abbddfd7618f8ccd63a74d88deea94e77d0e8dbbea059fa7ebebb8fbb4e2909667fe26f3a467073de1a542ebe6ae4c73a73745ac5833786759cd906c9
+  languageName: node
+  linkType: hard
+
 "cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
@@ -1953,6 +2270,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"decompress-response@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "decompress-response@npm:6.0.0"
+  dependencies:
+    mimic-response: "npm:^3.1.0"
+  checksum: 10c0/bd89d23141b96d80577e70c54fb226b2f40e74a6817652b80a116d7befb8758261ad073a8895648a29cc0a5947021ab66705cb542fa9c143c82022b27c5b175e
+  languageName: node
+  linkType: hard
+
 "dedent@npm:^1.6.0":
   version: 1.7.2
   resolution: "dedent@npm:1.7.2"
@@ -1962,6 +2288,13 @@ __metadata:
     babel-plugin-macros:
       optional: true
   checksum: 10c0/acaff07cac355b93f17b1b17ebbb84d3cc55af6ab4b7814c3f505e061903e168bc6bf9ddce331552d64dee1525f0b4c549c9ade46aebfac6f69caaed74e90751
+  languageName: node
+  linkType: hard
+
+"deep-extend@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "deep-extend@npm:0.6.0"
+  checksum: 10c0/1c6b0abcdb901e13a44c7d699116d3d4279fdb261983122a3783e7273844d5f2537dc2e1c454a23fcf645917f93fbf8d07101c1d03c015a87faa662755212566
   languageName: node
   linkType: hard
 
@@ -1976,6 +2309,13 @@ __metadata:
   version: 6.1.0
   resolution: "detect-indent@npm:6.1.0"
   checksum: 10c0/dd83cdeda9af219cf77f5e9a0dc31d828c045337386cfb55ce04fad94ba872ee7957336834154f7647b89b899c3c7acc977c57a79b7c776b506240993f97acc7
+  languageName: node
+  linkType: hard
+
+"detect-libc@npm:^2.0.0":
+  version: 2.1.2
+  resolution: "detect-libc@npm:2.1.2"
+  checksum: 10c0/acc675c29a5649fa1fb6e255f993b8ee829e510b6b56b0910666949c80c364738833417d0edb5f90e4e46be17228b0f2b66a010513984e18b15deeeac49369c4
   languageName: node
   linkType: hard
 
@@ -2034,6 +2374,15 @@ __metadata:
   version: 9.2.2
   resolution: "emoji-regex@npm:9.2.2"
   checksum: 10c0/af014e759a72064cf66e6e694a7fc6b0ed3d8db680427b021a89727689671cefe9d04151b2cad51dbaf85d5ba790d061cd167f1cf32eb7b281f6368b3c181639
+  languageName: node
+  linkType: hard
+
+"end-of-stream@npm:^1.1.0, end-of-stream@npm:^1.4.1":
+  version: 1.4.5
+  resolution: "end-of-stream@npm:1.4.5"
+  dependencies:
+    once: "npm:^1.4.0"
+  checksum: 10c0/b0701c92a10b89afb1cb45bf54a5292c6f008d744eb4382fa559d54775ff31617d1d7bc3ef617575f552e24fad2c7c1a1835948c66b3f3a4be0a6c1f35c883d8
   languageName: node
   linkType: hard
 
@@ -2122,6 +2471,13 @@ __metadata:
   version: 0.2.2
   resolution: "exit-x@npm:0.2.2"
   checksum: 10c0/212a7a095ca5540e9581f1ef2d1d6a40df7a6027c8cc96e78ce1d16b86d1a88326d4a0eff8dff2b5ec1e68bb0c1edd5d0dfdde87df1869bf7514d4bc6a5cbd72
+  languageName: node
+  linkType: hard
+
+"expand-template@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "expand-template@npm:2.0.3"
+  checksum: 10c0/1c9e7afe9acadf9d373301d27f6a47b34e89b3391b1ef38b7471d381812537ef2457e620ae7f819d2642ce9c43b189b3583813ec395e2938319abe356a9b2f51
   languageName: node
   linkType: hard
 
@@ -2216,6 +2572,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"file-uri-to-path@npm:1.0.0":
+  version: 1.0.0
+  resolution: "file-uri-to-path@npm:1.0.0"
+  checksum: 10c0/3b545e3a341d322d368e880e1c204ef55f1d45cdea65f7efc6c6ce9e0c4d22d802d5629320eb779d006fe59624ac17b0e848d83cc5af7cd101f206cb704f5519
+  languageName: node
+  linkType: hard
+
 "fill-range@npm:^7.1.1":
   version: 7.1.1
   resolution: "fill-range@npm:7.1.1"
@@ -2242,6 +2605,13 @@ __metadata:
     cross-spawn: "npm:^7.0.6"
     signal-exit: "npm:^4.0.1"
   checksum: 10c0/8986e4af2430896e65bc2788d6679067294d6aee9545daefc84923a0a4b399ad9c7a3ea7bd8c0b2b80fdf4a92de4c69df3f628233ff3224260e9c1541a9e9ed3
+  languageName: node
+  linkType: hard
+
+"fs-constants@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "fs-constants@npm:1.0.0"
+  checksum: 10c0/a0cde99085f0872f4d244e83e03a46aa387b74f5a5af750896c6b05e9077fac00e9932fdf5aef84f2f16634cd473c63037d7a512576da7d5c2b9163d1909f3a8
   languageName: node
   linkType: hard
 
@@ -2321,6 +2691,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"github-from-package@npm:0.0.0":
+  version: 0.0.0
+  resolution: "github-from-package@npm:0.0.0"
+  checksum: 10c0/737ee3f52d0a27e26332cde85b533c21fcdc0b09fb716c3f8e522cfaa9c600d4a631dec9fcde179ec9d47cca89017b7848ed4d6ae6b6b78f936c06825b1fcc12
+  languageName: node
+  linkType: hard
+
+"gl@npm:^9.0.0-rc.10":
+  version: 9.0.0-rc.10
+  resolution: "gl@npm:9.0.0-rc.10"
+  dependencies:
+    bindings: "npm:^1.5.0"
+    bit-twiddle: "npm:^1.0.2"
+    glsl-tokenizer: "npm:^2.1.5"
+    nan: "npm:^2.26.2"
+    node-gyp: "npm:^12.2.0"
+    prebuild-install: "npm:^7.1.3"
+  checksum: 10c0/7543d5a1b8384024d67d0f3c046a76f274dccd579e89056313022ba55651824ea640d94dae824d528ae05d28fdd7677bfd34d2b6aa4c2d4628c8246063e7a3ed
+  languageName: node
+  linkType: hard
+
 "glob-parent@npm:^5.1.2":
   version: 5.1.2
   resolution: "glob-parent@npm:5.1.2"
@@ -2371,6 +2762,15 @@ __metadata:
     merge2: "npm:^1.4.1"
     slash: "npm:^3.0.0"
   checksum: 10c0/b39511b4afe4bd8a7aead3a27c4ade2b9968649abab0a6c28b1a90141b96ca68ca5db1302f7c7bd29eab66bf51e13916b8e0a3d0ac08f75e1e84a39b35691189
+  languageName: node
+  linkType: hard
+
+"glsl-tokenizer@npm:^2.1.5":
+  version: 2.1.5
+  resolution: "glsl-tokenizer@npm:2.1.5"
+  dependencies:
+    through2: "npm:^0.6.3"
+  checksum: 10c0/5bcc4491afb0b09032702af83f0afa8acadfa0f5c94a7a0d7c3498396cc35722e1915c976c8efef80a1a9ef0976ecb8ce4e044a34b16d7d537ae4c80f346ad19
   languageName: node
   linkType: hard
 
@@ -2452,6 +2852,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ieee754@npm:^1.1.13":
+  version: 1.2.1
+  resolution: "ieee754@npm:1.2.1"
+  checksum: 10c0/b0782ef5e0935b9f12883a2e2aa37baa75da6e66ce6515c168697b42160807d9330de9a32ec1ed73149aea02e0d822e572bca6f1e22bdcbd2149e13b050b17bb
+  languageName: node
+  linkType: hard
+
 "ignore@npm:^5.2.0":
   version: 5.3.2
   resolution: "ignore@npm:5.3.2"
@@ -2488,10 +2895,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2":
+"inherits@npm:2, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.1":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
+  languageName: node
+  linkType: hard
+
+"ini@npm:~1.3.0":
+  version: 1.3.8
+  resolution: "ini@npm:1.3.8"
+  checksum: 10c0/ec93838d2328b619532e4f1ff05df7909760b6f66d9c9e2ded11e5c1897d6f2f9980c54dd638f88654b00919ce31e827040631eab0a3969e4d1abefa0719516a
   languageName: node
   linkType: hard
 
@@ -2573,6 +2987,13 @@ __metadata:
   version: 1.0.2
   resolution: "is-windows@npm:1.0.2"
   checksum: 10c0/b32f418ab3385604a66f1b7a3ce39d25e8881dee0bd30816dc8344ef6ff9df473a732bcc1ec4e84fe99b2f229ae474f7133e8e93f9241686cfcf7eebe53ba7a5
+  languageName: node
+  linkType: hard
+
+"isarray@npm:0.0.1":
+  version: 0.0.1
+  resolution: "isarray@npm:0.0.1"
+  checksum: 10c0/ed1e62da617f71fe348907c71743b5ed550448b455f8d269f89a7c7ddb8ae6e962de3dab6a74a237b06f5eb7f6ece7a45ada8ce96d87fe972926530f91ae3311
   languageName: node
   linkType: hard
 
@@ -3289,6 +3710,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mimic-response@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "mimic-response@npm:3.1.0"
+  checksum: 10c0/0d6f07ce6e03e9e4445bee655202153bdb8a98d67ee8dc965ac140900d7a2688343e6b4c9a72cfc9ef2f7944dfd76eef4ab2482eb7b293a68b84916bac735362
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^3.0.4, minimatch@npm:^3.1.1":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
@@ -3307,7 +3735,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.2.5":
+"minimist@npm:^1.2.0, minimist@npm:^1.2.3, minimist@npm:^1.2.5":
   version: 1.2.8
   resolution: "minimist@npm:1.2.8"
   checksum: 10c0/19d3fcdca050087b84c2029841a093691a91259a47def2f18222f41e7645a0b7c44ef4b40e88a1e58a40c84d2ef0ee6047c55594d298146d0eb3f6b737c20ce6
@@ -3330,6 +3758,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mkdirp-classic@npm:^0.5.2, mkdirp-classic@npm:^0.5.3":
+  version: 0.5.3
+  resolution: "mkdirp-classic@npm:0.5.3"
+  checksum: 10c0/95371d831d196960ddc3833cc6907e6b8f67ac5501a6582f47dfae5eb0f092e9f8ce88e0d83afcae95d6e2b61a01741ba03714eeafb6f7a6e9dcc158ac85b168
+  languageName: node
+  linkType: hard
+
 "mri@npm:^1.2.0":
   version: 1.2.0
   resolution: "mri@npm:1.2.0"
@@ -3348,6 +3783,22 @@ __metadata:
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: 10c0/d924b57e7312b3b63ad21fc5b3dc0af5e78d61a1fc7cfb5457edaf26326bf62be5307cc87ffb6862ef1c2b33b0233cdb5d4f01c4c958cc0d660948b65a287a48
+  languageName: node
+  linkType: hard
+
+"nan@npm:^2.26.2":
+  version: 2.26.2
+  resolution: "nan@npm:2.26.2"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/ff204c964729279cf3abb8b170c77753ed36092e2235f11bfb0204dfd3e8cc2d5a3bcfdfd3b677f06a0743d7f835d873dce59f23a2dbf6fb671d9351cc655d73
+  languageName: node
+  linkType: hard
+
+"napi-build-utils@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "napi-build-utils@npm:2.0.0"
+  checksum: 10c0/5833aaeb5cc5c173da47a102efa4680a95842c13e0d9cc70428bd3ee8d96bb2172f8860d2811799b5daa5cbeda779933601492a2028a6a5351c6d0fcf6de83db
   languageName: node
   linkType: hard
 
@@ -3393,7 +3844,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-gyp@npm:latest":
+"node-abi@npm:^3.3.0":
+  version: 3.89.0
+  resolution: "node-abi@npm:3.89.0"
+  dependencies:
+    semver: "npm:^7.3.5"
+  checksum: 10c0/73abbee70833fbf91c7a0bb52bef9f1ccde190b1597f0bf8f15226b3aef8a4ade78605488fbd0aa47ec4fefe20e748672ba045c9075c58a56416bde8d9097586
+  languageName: node
+  linkType: hard
+
+"node-gyp@npm:^12.2.0, node-gyp@npm:latest":
   version: 12.3.0
   resolution: "node-gyp@npm:12.3.0"
   dependencies:
@@ -3454,7 +3914,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"once@npm:^1.3.0":
+"once@npm:^1.3.0, once@npm:^1.3.1, once@npm:^1.4.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
   dependencies:
@@ -3476,6 +3936,148 @@ __metadata:
   version: 0.5.0
   resolution: "outdent@npm:0.5.0"
   checksum: 10c0/e216a4498889ba1babae06af84cdc4091f7cac86da49d22d0163b3be202a5f52efcd2bcd3dfca60a361eb3a27b4299f185c5655061b6b402552d7fcd1d040cff
+  languageName: node
+  linkType: hard
+
+"oxfmt@npm:^0.47.0":
+  version: 0.47.0
+  resolution: "oxfmt@npm:0.47.0"
+  dependencies:
+    "@oxfmt/binding-android-arm-eabi": "npm:0.47.0"
+    "@oxfmt/binding-android-arm64": "npm:0.47.0"
+    "@oxfmt/binding-darwin-arm64": "npm:0.47.0"
+    "@oxfmt/binding-darwin-x64": "npm:0.47.0"
+    "@oxfmt/binding-freebsd-x64": "npm:0.47.0"
+    "@oxfmt/binding-linux-arm-gnueabihf": "npm:0.47.0"
+    "@oxfmt/binding-linux-arm-musleabihf": "npm:0.47.0"
+    "@oxfmt/binding-linux-arm64-gnu": "npm:0.47.0"
+    "@oxfmt/binding-linux-arm64-musl": "npm:0.47.0"
+    "@oxfmt/binding-linux-ppc64-gnu": "npm:0.47.0"
+    "@oxfmt/binding-linux-riscv64-gnu": "npm:0.47.0"
+    "@oxfmt/binding-linux-riscv64-musl": "npm:0.47.0"
+    "@oxfmt/binding-linux-s390x-gnu": "npm:0.47.0"
+    "@oxfmt/binding-linux-x64-gnu": "npm:0.47.0"
+    "@oxfmt/binding-linux-x64-musl": "npm:0.47.0"
+    "@oxfmt/binding-openharmony-arm64": "npm:0.47.0"
+    "@oxfmt/binding-win32-arm64-msvc": "npm:0.47.0"
+    "@oxfmt/binding-win32-ia32-msvc": "npm:0.47.0"
+    "@oxfmt/binding-win32-x64-msvc": "npm:0.47.0"
+    tinypool: "npm:2.1.0"
+  dependenciesMeta:
+    "@oxfmt/binding-android-arm-eabi":
+      optional: true
+    "@oxfmt/binding-android-arm64":
+      optional: true
+    "@oxfmt/binding-darwin-arm64":
+      optional: true
+    "@oxfmt/binding-darwin-x64":
+      optional: true
+    "@oxfmt/binding-freebsd-x64":
+      optional: true
+    "@oxfmt/binding-linux-arm-gnueabihf":
+      optional: true
+    "@oxfmt/binding-linux-arm-musleabihf":
+      optional: true
+    "@oxfmt/binding-linux-arm64-gnu":
+      optional: true
+    "@oxfmt/binding-linux-arm64-musl":
+      optional: true
+    "@oxfmt/binding-linux-ppc64-gnu":
+      optional: true
+    "@oxfmt/binding-linux-riscv64-gnu":
+      optional: true
+    "@oxfmt/binding-linux-riscv64-musl":
+      optional: true
+    "@oxfmt/binding-linux-s390x-gnu":
+      optional: true
+    "@oxfmt/binding-linux-x64-gnu":
+      optional: true
+    "@oxfmt/binding-linux-x64-musl":
+      optional: true
+    "@oxfmt/binding-openharmony-arm64":
+      optional: true
+    "@oxfmt/binding-win32-arm64-msvc":
+      optional: true
+    "@oxfmt/binding-win32-ia32-msvc":
+      optional: true
+    "@oxfmt/binding-win32-x64-msvc":
+      optional: true
+  bin:
+    oxfmt: bin/oxfmt
+  checksum: 10c0/2651c383e1a35d88e573a74e714e618cb0dcc0ec9c522dcbd822baa75aa2d793bd657d8abdfbb3e27f0a9886be174ebe620f842a7c0e86a18c7b591d59f649c1
+  languageName: node
+  linkType: hard
+
+"oxlint@npm:^1.62.0":
+  version: 1.62.0
+  resolution: "oxlint@npm:1.62.0"
+  dependencies:
+    "@oxlint/binding-android-arm-eabi": "npm:1.62.0"
+    "@oxlint/binding-android-arm64": "npm:1.62.0"
+    "@oxlint/binding-darwin-arm64": "npm:1.62.0"
+    "@oxlint/binding-darwin-x64": "npm:1.62.0"
+    "@oxlint/binding-freebsd-x64": "npm:1.62.0"
+    "@oxlint/binding-linux-arm-gnueabihf": "npm:1.62.0"
+    "@oxlint/binding-linux-arm-musleabihf": "npm:1.62.0"
+    "@oxlint/binding-linux-arm64-gnu": "npm:1.62.0"
+    "@oxlint/binding-linux-arm64-musl": "npm:1.62.0"
+    "@oxlint/binding-linux-ppc64-gnu": "npm:1.62.0"
+    "@oxlint/binding-linux-riscv64-gnu": "npm:1.62.0"
+    "@oxlint/binding-linux-riscv64-musl": "npm:1.62.0"
+    "@oxlint/binding-linux-s390x-gnu": "npm:1.62.0"
+    "@oxlint/binding-linux-x64-gnu": "npm:1.62.0"
+    "@oxlint/binding-linux-x64-musl": "npm:1.62.0"
+    "@oxlint/binding-openharmony-arm64": "npm:1.62.0"
+    "@oxlint/binding-win32-arm64-msvc": "npm:1.62.0"
+    "@oxlint/binding-win32-ia32-msvc": "npm:1.62.0"
+    "@oxlint/binding-win32-x64-msvc": "npm:1.62.0"
+  peerDependencies:
+    oxlint-tsgolint: ">=0.18.0"
+  dependenciesMeta:
+    "@oxlint/binding-android-arm-eabi":
+      optional: true
+    "@oxlint/binding-android-arm64":
+      optional: true
+    "@oxlint/binding-darwin-arm64":
+      optional: true
+    "@oxlint/binding-darwin-x64":
+      optional: true
+    "@oxlint/binding-freebsd-x64":
+      optional: true
+    "@oxlint/binding-linux-arm-gnueabihf":
+      optional: true
+    "@oxlint/binding-linux-arm-musleabihf":
+      optional: true
+    "@oxlint/binding-linux-arm64-gnu":
+      optional: true
+    "@oxlint/binding-linux-arm64-musl":
+      optional: true
+    "@oxlint/binding-linux-ppc64-gnu":
+      optional: true
+    "@oxlint/binding-linux-riscv64-gnu":
+      optional: true
+    "@oxlint/binding-linux-riscv64-musl":
+      optional: true
+    "@oxlint/binding-linux-s390x-gnu":
+      optional: true
+    "@oxlint/binding-linux-x64-gnu":
+      optional: true
+    "@oxlint/binding-linux-x64-musl":
+      optional: true
+    "@oxlint/binding-openharmony-arm64":
+      optional: true
+    "@oxlint/binding-win32-arm64-msvc":
+      optional: true
+    "@oxlint/binding-win32-ia32-msvc":
+      optional: true
+    "@oxlint/binding-win32-x64-msvc":
+      optional: true
+  peerDependenciesMeta:
+    oxlint-tsgolint:
+      optional: true
+  bin:
+    oxlint: bin/oxlint
+  checksum: 10c0/12045a9ab4054d25d56d55edf73e64dbe9418aeb84e46e5aacfbfe49a50a29d9897dc078e86c3a82c2adeec38df2e756431644d6df78a94265850952f49117bf
   languageName: node
   linkType: hard
 
@@ -3639,6 +4241,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prebuild-install@npm:^7.1.3":
+  version: 7.1.3
+  resolution: "prebuild-install@npm:7.1.3"
+  dependencies:
+    detect-libc: "npm:^2.0.0"
+    expand-template: "npm:^2.0.3"
+    github-from-package: "npm:0.0.0"
+    minimist: "npm:^1.2.3"
+    mkdirp-classic: "npm:^0.5.3"
+    napi-build-utils: "npm:^2.0.0"
+    node-abi: "npm:^3.3.0"
+    pump: "npm:^3.0.0"
+    rc: "npm:^1.2.7"
+    simple-get: "npm:^4.0.0"
+    tar-fs: "npm:^2.0.0"
+    tunnel-agent: "npm:^0.6.0"
+  bin:
+    prebuild-install: bin.js
+  checksum: 10c0/25919a42b52734606a4036ab492d37cfe8b601273d8dfb1fa3c84e141a0a475e7bad3ab848c741d2f810cef892fcf6059b8c7fe5b29f98d30e0c29ad009bedff
+  languageName: node
+  linkType: hard
+
 "prettier@npm:^2.7.1":
   version: 2.8.8
   resolution: "prettier@npm:2.8.8"
@@ -3666,6 +4290,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pump@npm:^3.0.0":
+  version: 3.0.4
+  resolution: "pump@npm:3.0.4"
+  dependencies:
+    end-of-stream: "npm:^1.1.0"
+    once: "npm:^1.3.1"
+  checksum: 10c0/2780e66b5471c19e3e3e1063b84f3f6a3a08367f24c5ed552f98cd5901e6ada27c7ad6495d4244f553fd03b01884a4561933064f053f47c8994d84fd352768ea
+  languageName: node
+  linkType: hard
+
 "pure-rand@npm:^7.0.0":
   version: 7.0.1
   resolution: "pure-rand@npm:7.0.1"
@@ -3687,6 +4321,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rc@npm:^1.2.7":
+  version: 1.2.8
+  resolution: "rc@npm:1.2.8"
+  dependencies:
+    deep-extend: "npm:^0.6.0"
+    ini: "npm:~1.3.0"
+    minimist: "npm:^1.2.0"
+    strip-json-comments: "npm:~2.0.1"
+  bin:
+    rc: ./cli.js
+  checksum: 10c0/24a07653150f0d9ac7168e52943cc3cb4b7a22c0e43c7dff3219977c2fdca5a2760a304a029c20811a0e79d351f57d46c9bde216193a0f73978496afc2b85b15
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^18.3.1":
   version: 18.3.1
   resolution: "react-is@npm:18.3.1"
@@ -3703,6 +4351,29 @@ __metadata:
     pify: "npm:^4.0.1"
     strip-bom: "npm:^3.0.0"
   checksum: 10c0/85a9ba08bb93f3c91089bab4f1603995ec7156ee595f8ce40ae9f49d841cbb586511508bd47b7cf78c97f678c679b2c6e2c0092e63f124214af41b6f8a25ca31
+  languageName: node
+  linkType: hard
+
+"readable-stream@npm:>=1.0.33-1 <1.1.0-0":
+  version: 1.0.34
+  resolution: "readable-stream@npm:1.0.34"
+  dependencies:
+    core-util-is: "npm:~1.0.0"
+    inherits: "npm:~2.0.1"
+    isarray: "npm:0.0.1"
+    string_decoder: "npm:~0.10.x"
+  checksum: 10c0/02272551396ed8930ddee1a088bdf0379f0f7cc47ac49ed8804e998076cb7daec9fbd2b1fd9c0490ec72e56e8bb3651abeb8080492b8e0a9c3f2158330908ed6
+  languageName: node
+  linkType: hard
+
+"readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0":
+  version: 3.6.2
+  resolution: "readable-stream@npm:3.6.2"
+  dependencies:
+    inherits: "npm:^2.0.3"
+    string_decoder: "npm:^1.1.1"
+    util-deprecate: "npm:^1.0.1"
+  checksum: 10c0/e37be5c79c376fdd088a45fa31ea2e423e5d48854be7a22a58869b4e84d25047b193f6acb54f1012331e1bcd667ffb569c01b99d36b0bd59658fb33f513511b7
   languageName: node
   linkType: hard
 
@@ -3742,6 +4413,13 @@ __metadata:
   dependencies:
     queue-microtask: "npm:^1.2.2"
   checksum: 10c0/200b5ab25b5b8b7113f9901bfe3afc347e19bb7475b267d55ad0eb86a62a46d77510cb0f232507c9e5d497ebda569a08a9867d0d14f57a82ad5564d991588b39
+  languageName: node
+  linkType: hard
+
+"safe-buffer@npm:^5.0.1, safe-buffer@npm:~5.2.0":
+  version: 5.2.1
+  resolution: "safe-buffer@npm:5.2.1"
+  checksum: 10c0/6501914237c0a86e9675d4e51d89ca3c21ffd6a31642efeba25ad65720bce6921c9e7e974e5be91a786b25aa058b5303285d3c15dbabf983a919f5f630d349f3
   languageName: node
   linkType: hard
 
@@ -3817,6 +4495,24 @@ __metadata:
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 10c0/41602dce540e46d599edba9d9860193398d135f7ff72cab629db5171516cfae628d21e7bfccde1bbfdf11c48726bc2a6d1a8fb8701125852fbfda7cf19c6aa83
+  languageName: node
+  linkType: hard
+
+"simple-concat@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "simple-concat@npm:1.0.1"
+  checksum: 10c0/62f7508e674414008910b5397c1811941d457dfa0db4fd5aa7fa0409eb02c3609608dfcd7508cace75b3a0bf67a2a77990711e32cd213d2c76f4fd12ee86d776
+  languageName: node
+  linkType: hard
+
+"simple-get@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "simple-get@npm:4.0.1"
+  dependencies:
+    decompress-response: "npm:^6.0.0"
+    once: "npm:^1.3.1"
+    simple-concat: "npm:^1.0.0"
+  checksum: 10c0/b0649a581dbca741babb960423248899203165769747142033479a7dc5e77d7b0fced0253c731cd57cf21e31e4d77c9157c3069f4448d558ebc96cf9e1eebcf0
   languageName: node
   linkType: hard
 
@@ -3902,6 +4598,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"string_decoder@npm:^1.1.1":
+  version: 1.3.0
+  resolution: "string_decoder@npm:1.3.0"
+  dependencies:
+    safe-buffer: "npm:~5.2.0"
+  checksum: 10c0/810614ddb030e271cd591935dcd5956b2410dd079d64ff92a1844d6b7588bf992b3e1b69b0f4d34a3e06e0bd73046ac646b5264c1987b20d0601f81ef35d731d
+  languageName: node
+  linkType: hard
+
+"string_decoder@npm:~0.10.x":
+  version: 0.10.31
+  resolution: "string_decoder@npm:0.10.31"
+  checksum: 10c0/1c628d78f974aa7539c496029f48e7019acc32487fc695464f9d6bdfec98edd7d933a06b3216bc2016918f6e75074c611d84430a53cb0e43071597d6c1ac5e25
+  languageName: node
+  linkType: hard
+
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1, strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
   version: 6.0.1
   resolution: "strip-ansi@npm:6.0.1"
@@ -3948,6 +4660,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strip-json-comments@npm:~2.0.1":
+  version: 2.0.1
+  resolution: "strip-json-comments@npm:2.0.1"
+  checksum: 10c0/b509231cbdee45064ff4f9fd73609e2bcc4e84a4d508e9dd0f31f70356473fde18abfb5838c17d56fb236f5a06b102ef115438de0600b749e818a35fbbc48c43
+  languageName: node
+  linkType: hard
+
 "supports-color@npm:^5.3.0":
   version: 5.5.0
   resolution: "supports-color@npm:5.5.0"
@@ -3984,6 +4703,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tar-fs@npm:^2.0.0":
+  version: 2.1.4
+  resolution: "tar-fs@npm:2.1.4"
+  dependencies:
+    chownr: "npm:^1.1.1"
+    mkdirp-classic: "npm:^0.5.2"
+    pump: "npm:^3.0.0"
+    tar-stream: "npm:^2.1.4"
+  checksum: 10c0/decb25acdc6839182c06ec83cba6136205bda1db984e120c8ffd0d80182bc5baa1d916f9b6c5c663ea3f9975b4dd49e3c6bb7b1707cbcdaba4e76042f43ec84c
+  languageName: node
+  linkType: hard
+
+"tar-stream@npm:^2.1.4":
+  version: 2.2.0
+  resolution: "tar-stream@npm:2.2.0"
+  dependencies:
+    bl: "npm:^4.0.3"
+    end-of-stream: "npm:^1.4.1"
+    fs-constants: "npm:^1.0.0"
+    inherits: "npm:^2.0.3"
+    readable-stream: "npm:^3.1.1"
+  checksum: 10c0/2f4c910b3ee7196502e1ff015a7ba321ec6ea837667220d7bcb8d0852d51cb04b87f7ae471008a6fb8f5b1a1b5078f62f3a82d30c706f20ada1238ac797e7692
+  languageName: node
+  linkType: hard
+
 "tar@npm:^7.5.4":
   version: 7.5.13
   resolution: "tar@npm:7.5.13"
@@ -4015,6 +4759,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"through2@npm:^0.6.3":
+  version: 0.6.5
+  resolution: "through2@npm:0.6.5"
+  dependencies:
+    readable-stream: "npm:>=1.0.33-1 <1.1.0-0"
+    xtend: "npm:>=4.0.0 <4.1.0-0"
+  checksum: 10c0/3294325d73b120ffbb8cd00e28a649a99e194cef2638bf782b6c2eb0c163b388f7b7bb908003949f58f9f6b8f771defd24b6e4df051eb410fd87931521963b98
+  languageName: node
+  linkType: hard
+
 "tinyglobby@npm:^0.2.12":
   version: 0.2.16
   resolution: "tinyglobby@npm:0.2.16"
@@ -4022,6 +4776,13 @@ __metadata:
     fdir: "npm:^6.5.0"
     picomatch: "npm:^4.0.4"
   checksum: 10c0/f2e09fd93dd95c41e522113b686ff6f7c13020962f8698a864a257f3d7737599afc47722b7ab726e12f8a813f779906187911ff8ee6701ede65072671a7e934b
+  languageName: node
+  linkType: hard
+
+"tinypool@npm:2.1.0":
+  version: 2.1.0
+  resolution: "tinypool@npm:2.1.0"
+  checksum: 10c0/9fb1c760558c6264e0f4cfde96a63b12450b43f1730fbe6274aa24ddbdf488745c08924d0dea7a1303b47d555416a6415f2113898c69b6ecf731e75ac95238a5
   languageName: node
   linkType: hard
 
@@ -4092,6 +4853,15 @@ __metadata:
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
+  languageName: node
+  linkType: hard
+
+"tunnel-agent@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "tunnel-agent@npm:0.6.0"
+  dependencies:
+    safe-buffer: "npm:^5.0.1"
+  checksum: 10c0/4c7a1b813e7beae66fdbf567a65ec6d46313643753d0beefb3c7973d66fcec3a1e7f39759f0a0b4465883499c6dc8b0750ab8b287399af2e583823e40410a17a
   languageName: node
   linkType: hard
 
@@ -4264,6 +5034,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"util-deprecate@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "util-deprecate@npm:1.0.2"
+  checksum: 10c0/41a5bdd214df2f6c3ecf8622745e4a366c4adced864bc3c833739791aeeeb1838119af7daed4ba36428114b5c67dcda034a79c882e97e43c03e66a4dd7389942
+  languageName: node
+  linkType: hard
+
 "v8-to-istanbul@npm:^9.0.1":
   version: 9.3.0
   resolution: "v8-to-istanbul@npm:9.3.0"
@@ -4350,9 +5127,15 @@ __metadata:
     "@types/jest": "npm:^30.0.0"
     "@types/ndarray": "npm:^1.0.14"
     "@types/node": "npm:^25.6.0"
+    gl: "npm:^9.0.0-rc.10"
     jest: "npm:^30.3.0"
+    oxfmt: "npm:^0.47.0"
+    oxlint: "npm:^1.62.0"
     ts-jest: "npm:^29"
     typescript: "npm:^6"
+  dependenciesMeta:
+    gl:
+      built: true
   languageName: unknown
   linkType: soft
 
@@ -4463,6 +5246,13 @@ __metadata:
     imurmurhash: "npm:^0.1.4"
     signal-exit: "npm:^4.0.1"
   checksum: 10c0/e8c850a8e3e74eeadadb8ad23c9d9d63e4e792bd10f4836ed74189ef6e996763959f1249c5650e232f3c77c11169d239cbfc8342fc70f3fe401407d23810505d
+  languageName: node
+  linkType: hard
+
+"xtend@npm:>=4.0.0 <4.1.0-0":
+  version: 4.0.2
+  resolution: "xtend@npm:4.0.2"
+  checksum: 10c0/366ae4783eec6100f8a02dff02ac907bf29f9a00b82ac0264b4d8b832ead18306797e283cf19de776538babfdcb2101375ec5646b59f08c52128ac4ab812ed0e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #44, #45, #46.

## Lint / format (oxc)

- **oxlint** with `correctness=error`, `suspicious=warn`, `perf=warn` plus a few rules disabled where they conflict with library patterns.
- **oxfmt** scoped to `packages/**/*.{ts,tsx}` and `jest.config.js` so prose edits to `README.md` don't churn. Globs in scripts use double quotes for Windows portability.
- Scripts: `yarn lint`, `yarn format`, `yarn format:fix`, `yarn typecheck`.

Pre-existing files cleaned up to clear lint:

- `&& obj.x` → `?.x` optional chains
- `forEach` returning values → `for..of`
- `drawNDArrayTexture`: drop unused `texture` parameter
- `BufferShim` static-only class → `{ isBuffer: () => false }` literal
- `DeprecatedExpoGLObjectTextureLoader.loadNoCache`: extract `createObjectAsync` and reject explicitly when missing
- `globalRegistry`: function-form `??=` so the singleton doesn't trip no-assignment-in-expression

## CI (`.github/workflows/ci-tests.yml`)

Two parallel jobs:
- **lint** — Node 24, no apt deps. Just `yarn lint` + `yarn format`. Fast feedback.
- **test** — installs `xvfb libgl1 libxi6` only (gl@9 ships prebuilt Linux binaries), build, Jest under `xvfb-run`.

yarn cache is wired via `actions/cache@v4` keyed on `yarn.lock`, run **after** `corepack enable`. `setup-node@v4`'s `cache: yarn` doesn't work here: it queries yarn at action-config time, before our `corepack enable` step, and the global yarn 1.22 refuses when `packageManager` pins yarn@4.

## Headless-gl tests

- `gl@9.0.0-rc.10` (v8 fails on Node 24's V8 C++20 headers). `dependenciesMeta.gl.built = true` so Yarn 4 actually runs prebuild-install.
- `*.gl.test.ts` suffix. They `try { require("gl") }` and `describe.skip` if the binding isn't loadable, so local macOS without a working build still passes the rest of the suite.
- `beforeEach` creates a context, `afterEach` calls `STACKGL_destroy_context.destroy()` so tests don't leak GPU state.

`createTexture.gl.test.ts`:
- Full lifecycle via `gl.isTexture` (false before bind, true after, false after delete).

`NDArrayTextureLoader.gl.test.ts`:
- Real upload of a 2×2 RGBA uint8 ndarray verified via `gl.readPixels` (catches broken uploads, not just identity)
- `dispose()` deletes every cached texture
- `update()` rewrites the same texture in place; `readPixels` confirms the GPU saw the new bytes
- 2D shape → LUMINANCE; 3D RGB; rejection of unsupported channel counts; rejection of shapes > MAX_TEXTURE_SIZE

`integration.gl.test.ts`:
- `LoaderResolver` + custom `LoadersRegistry` + `NDArrayTextureLoader` end-to-end resolves an ndarray and produces a real `WebGLTexture`; rejects unrelated inputs; dispose cascades.

## Mock-based unit tests for documented contracts

- `LoadersRegistry`: priority sort across multiple `add()`, default 0, `remove()` is a no-op for unknown classes.
- `LoaderResolver`: rejects unsupported input, picks the highest-priority matching loader, `dispose()` cascades.
- `WebGLTextureLoaderAsyncHashCache`: `load()` idempotency (same Promise on repeat), `cancelLoad()` invokes underlying dispose, `dispose()` during pending load drops the late result, `dispose()` deletes each cached texture exactly once, `loadNoCache` rejection propagates.
- `WebGLTextureLoaderSyncHashCache`: `get()` caches, `load()` idempotency, `dispose()` deletes each cached texture.

## Test plan

- [x] Local: `yarn install` clean
- [x] Local: `yarn build` (~1.5s parallel topo)
- [x] Local: `yarn lint` 0/0
- [x] Local: `yarn format` clean
- [x] Local: `yarn test` 9 suites / 29 tests / ~0.5s (4 real-GL tests included)
- [x] CI green (commit a09abbc, replaced by 97dd799 with Copilot review fixes)

## Coverage delta

| Suite | Tests |
|---|---|
| LoaderResolver | 4 |
| LoadersRegistry (NEW) | 4 |
| AsyncHashCache | 6 |
| SyncHashCache | 3 |
| WebGLTextureLoader | 2 |
| globalRegistry | 1 |
| createTexture.gl | 1 |
| NDArrayTextureLoader.gl | 7 |
| integration.gl (NEW) | 1 |
| **Total** | **29** |

Not covered: DOM loaders (need a real browser harness — headless-gl's `texImage2D` doesn't accept jsdom + node-canvas types), WebGL2 branches in `drawNDArrayTexture` (`headless-gl` is WebGL1 only), RN/Expo loaders (peer-deps native).