### PR TITLE
fix(expo): drop deprecated expo-asset-utils, use Image.getSize for remote dimensions

### DIFF
--- a/packages/webgltexture-loader-expo/package.json
+++ b/packages/webgltexture-loader-expo/package.json
@@ -16,10 +16,10 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "expo-asset-utils": "^3.0.0",
     "webgltexture-loader": "^2.0.0"
   },
   "peerDependencies": {
+    "expo-asset": "*",
     "expo-modules-core": "*",
     "react-native": "*"
   }

--- a/packages/webgltexture-loader-expo/src/ExpoModuleTextureLoader.ts
+++ b/packages/webgltexture-loader-expo/src/ExpoModuleTextureLoader.ts
@@ -1,5 +1,5 @@
 import { Asset } from "expo-asset";
-import * as AssetUtils from "expo-asset-utils";
+import { Image } from "react-native";
 import {
   createTexture,
   globalRegistry,
@@ -17,19 +17,43 @@ type AssetModel = {
 
 type Input = number | { uri: string } | AssetModel;
 
-const localAsset = (module: number): Promise<Asset> => {
-  const asset = Asset.fromModule(module);
-  return asset.downloadAsync().then(() => asset);
-};
+const getImageSize = (uri: string): Promise<{ width: number; height: number }> =>
+  new Promise((resolve, reject) => {
+    Image.getSize(
+      uri,
+      (width, height) => resolve({ width, height }),
+      (error) => reject(new Error(`Image.getSize failed for ${uri}`, { cause: error })),
+    );
+  });
 
-export const loadAsset = (module: Input): Promise<AssetModel> => {
+export const loadAsset = async (module: Input): Promise<AssetModel> => {
+  // 1. Numeric module id (`require("./img.png")`) — download via Asset.
   if (typeof module === "number") {
-    return localAsset(module) as Promise<unknown> as Promise<AssetModel>;
+    return Asset.fromModule(module).downloadAsync();
   }
-  if ("localUri" in module && module.localUri) {
-    return Promise.resolve(module as AssetModel);
+
+  // 2. Pre-resolved asset with concrete dimensions — trust the caller.
+  const m = module as Partial<AssetModel> & { uri: string };
+  if (typeof m.width === "number" && typeof m.height === "number") {
+    return m as AssetModel;
   }
-  return AssetUtils.resolveAsync(module.uri) as Promise<AssetModel>;
+
+  // 3. Pre-resolved local file but dimensions are missing/null — just measure.
+  if (m.localUri) {
+    const { width, height } = await getImageSize(m.localUri);
+    return { ...m, width, height };
+  }
+
+  // 4. Bare URI — download then measure (expo-asset returns null width/height
+  //    for remote URIs on iOS/Android, hence Image.getSize).
+  const [asset] = await Asset.loadAsync(m.uri);
+  if (!asset) {
+    throw new Error(`Asset.loadAsync returned no asset for ${m.uri}`);
+  }
+  const { width, height } = await getImageSize(asset.localUri ?? asset.uri);
+  asset.width = width;
+  asset.height = height;
+  return asset;
 };
 
 export default class ExpoModuleTextureLoader extends WebGLTextureLoaderAsyncHashCache<Input> {
@@ -55,9 +79,6 @@ export default class ExpoModuleTextureLoader extends WebGLTextureLoaderAsyncHash
     const promise = loadAsset(module).then((asset) => {
       if (disposed) return neverEnding;
       const { width, height, uri } = asset;
-      // expo-asset can return null width/height on iOS/Android for remote
-      // images (tracked in PR #41). Fail loudly with the URI rather than
-      // pass NaN to texImage2D.
       if (typeof width !== "number" || typeof height !== "number") {
         throw new Error(
           `Expo asset has no dimensions (width=${width}, height=${height}, uri=${uri})`,

--- a/packages/webgltexture-loader-expo/src/types.d.ts
+++ b/packages/webgltexture-loader-expo/src/types.d.ts
@@ -10,10 +10,21 @@ declare module "expo-modules-core" {
 declare module "expo-asset" {
   export class Asset {
     static fromModule(module: number): Asset;
+    static loadAsync(uri: string | string[]): Promise<Asset[]>;
     downloadAsync(): Promise<this>;
     width: number | null;
     height: number | null;
     uri: string;
     localUri?: string | null;
   }
+}
+
+declare module "react-native" {
+  export const Image: {
+    getSize(
+      uri: string,
+      success: (width: number, height: number) => void,
+      failure?: (error: unknown) => void,
+    ): void;
+  };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2495,19 +2495,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-asset-utils@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "expo-asset-utils@npm:3.0.0"
-  peerDependencies:
-    expo-asset: "*"
-    expo-file-system: "*"
-    expo-font: "*"
-    expo-modules-core: "*"
-    react-native: "*"
-  checksum: 10c0/bfb97ec92dede4412a8d8b4dc13e0e0aab358c0a57852bd48506e12a19a6f17f20d7281172007ad4733ce1782658aecf6932c9ba8b47b2d5245cf2830f48ef69
-  languageName: node
-  linkType: hard
-
 "exponential-backoff@npm:^3.1.1":
   version: 3.1.3
   resolution: "exponential-backoff@npm:3.1.3"
@@ -5099,9 +5086,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "webgltexture-loader-expo@workspace:packages/webgltexture-loader-expo"
   dependencies:
-    expo-asset-utils: "npm:^3.0.0"
     webgltexture-loader: "npm:^2.0.0"
   peerDependencies:
+    expo-asset: "*"
     expo-modules-core: "*"
     react-native: "*"
   languageName: unknown


### PR DESCRIPTION
Ports #41 (by @pycxxx) to the TypeScript codebase. Original commit credited via `Co-Authored-By` trailer.

## Why

`expo-asset-utils` is deprecated and unmaintained. Separately, `expo-asset` returns `null` for `width`/`height` when loading remote URIs on iOS / Android (see https://github.com/expo/expo/blob/d8d7919/packages/expo-asset/src/Asset.ts#L251-L261), so the previous code happily fed `NaN` into `texImage2D`.

## Changes

- Drop `expo-asset-utils` from `webgltexture-loader-expo` dependencies.
- Move `expo-asset` to `peerDependencies` alongside `expo-modules-core` and `react-native`.
- Replace `AssetUtils.resolveAsync(uri)` with `Asset.loadAsync(uri)` + `Image.getSize(uri)` (from `react-native`) to fetch the missing dimensions and patch the asset before passing it to `texImage2D`.
- Local-asset (`require("./img.png")`) and pre-resolved (`{ localUri }`) paths are unchanged.
- Extend `src/types.d.ts` with `Asset.loadAsync`, `Image.getSize`, and a `react-native` module declaration so the package type-checks without installing the peer-deps.

The defensive `if (typeof width !== "number" ...) throw` in `loadNoCache` (introduced earlier in #48 in response to Copilot review) is kept: `Image.getSize` should always return numbers, but if a future code path skips it we'd rather fail with a clear URI than feed `NaN` to the GPU.

## Test plan

- [x] `yarn install` clean (peer warning about `expo-asset-utils` is gone)
- [x] `yarn build` green (`expo` package now type-checks against the new `expo-asset` / `react-native` stubs)
- [x] `yarn test` 9 suites / 29 tests
- [x] `yarn lint` 0/0
- [x] `yarn format` clean
- [ ] Manual smoke against an Expo SDK 51+ app loading a remote `https://...` image — pending real device

Closes #41