### PR TITLE
feat(ndarray): support 16/32-bit integer dtypes via WebGL2 integer textures

### DIFF
--- a/apps/example-web/README.md
+++ b/apps/example-web/README.md
@@ -17,15 +17,30 @@ declare `main: lib/index.js`, and `lib/` is only produced by their build.
 
 ## What it shows
 
-A WebGL canvas split into a 2x2 grid, each quadrant sampling a different
-loader:
+The demo requests a **WebGL2** context first and falls back to WebGL1 if the
+browser doesn't have one (the sidebar pill makes the choice visible).
 
-| Quadrant     | Loader                       | Source                                   |
-| ------------ | ---------------------------- | ---------------------------------------- |
-| top-left     | `CanvasTextureLoader`        | A programmatic `HTMLCanvasElement` (gradient + circle + label). |
-| top-right    | `ImageURLTextureLoader`      | A `data:image/png` URL generated at runtime (offline-friendly). |
-| bottom-left  | `VideoTextureLoader`         | A CC0 webm streamed from MDN's media bucket (`Access-Control-Allow-Origin: *`, required for `crossOrigin="anonymous"`). |
-| bottom-right | `NDArrayTextureLoader`       | A 64x64 RGBA `Uint8Array` plasma pattern wrapped with `ndarray`. |
+### WebGL2 (3x2 grid, default)
+
+| Cell        | Loader                  | Source                                                                                                  |
+| ----------- | ----------------------- | ------------------------------------------------------------------------------------------------------- |
+| top-left    | `CanvasTextureLoader`   | A programmatic `HTMLCanvasElement` (gradient + circle + label).                                         |
+| top-mid     | `ImageURLTextureLoader` | A `data:image/png` URL generated at runtime (offline-friendly).                                         |
+| top-right   | `VideoTextureLoader`    | A CC0 webm from MDN's media bucket.                                                                     |
+| bottom-left | `NDArrayTextureLoader`  | A 256x256 RGBA gamma-ramp gradient downcast from Uint16 (`v >> 8`) — same pixels as the cell to its right but uploaded as `uint8`. |
+| bottom-mid  | `NDArrayTextureLoader`  | The same 256x256 gradient as a `Uint16Array` ndarray, uploaded via the WebGL2 integer-texture path (`RGBA16UI`) and sampled through a `usampler2D` divided by `65535.0`. |
+| bottom-right| —                       | Flat info panel (no texture).                                                                           |
+
+The bottom row is the precision comparison: a steep gamma ramp is laid out so
+the dark end stretches over many 16-bit codes that all collapse to a few 8-bit
+codes — the uint8 cell shows visible banding at the dark end while the uint16
+cell stays smooth.
+
+### WebGL1 fallback (2x2 grid)
+
+WebGL1 has no integer textures. The demo falls back to the original 2x2 grid
+(canvas + image + video + a 64x64 plasma `Uint8` ndarray) and the sidebar pill
+flips to a yellow `WebGL1` indicator.
 
 The sidebar shows each source's resolved size, the loader class that handled
 it, and a status indicator. The "Dispose all" button calls `resolver.dispose()`

--- a/apps/example-web/index.html
+++ b/apps/example-web/index.html
@@ -37,9 +37,15 @@
         background: #000;
         overflow: hidden;
       }
+      /* Default to a square (matches the WebGL1 2x2 fallback grid). The
+         WebGL2 path uses a 3x2 grid and updates `--aspect` from JS so each
+         cell stays square. */
+      :root { --aspect: 1; }
       #gl {
-        width: min(100%, calc(100vh * 1));
-        height: 100%;
+        width: min(100%, calc(100vh * var(--aspect)));
+        height: min(100%, calc(100vw / var(--aspect)));
+        max-width: 100%;
+        max-height: 100%;
         display: block;
       }
       .sidebar {
@@ -114,6 +120,28 @@
       button:hover { background: #353c4a; }
       button:disabled { opacity: 0.5; cursor: not-allowed; }
       a { color: #7ab7ff; }
+      .pill {
+        display: inline-block;
+        padding: 1px 6px;
+        border-radius: 999px;
+        font-size: 10px;
+        font-weight: 600;
+        letter-spacing: 0.5px;
+        text-transform: uppercase;
+        border: 1px solid var(--border);
+      }
+      .pill.ok { background: #1c3a23; border-color: #2c5b39; color: #b5e2c0; }
+      .pill.warn { background: #3a2f1c; border-color: #5b4a2c; color: #e2d3b5; }
+      .note {
+        margin-top: 12px;
+        padding: 8px 10px;
+        background: #11151c;
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        color: var(--muted);
+        font-size: 12px;
+        line-height: 1.4;
+      }
     </style>
   </head>
   <body>
@@ -123,8 +151,12 @@
       </div>
       <aside class="sidebar">
         <h1>webgltexture-loader demo</h1>
-        <div class="muted">Each quadrant samples a different loader.</div>
+        <div class="muted">
+          Each cell samples a different loader.
+          Context: <span id="gl-version" class="pill">…</span>
+        </div>
         <ul id="sources" class="sources"></ul>
+        <p id="note" class="note"></p>
         <button id="dispose">Dispose all</button>
         <p class="muted" style="margin-top:16px">
           Source: <a href="https://github.com/gre/webgltexture-loader">gre/webgltexture-loader</a>

--- a/apps/example-web/src/gl.ts
+++ b/apps/example-web/src/gl.ts
@@ -1,9 +1,28 @@
 /** Tiny WebGL helpers. Throws on any failure to keep the demo terse. */
 
-export function getGL(canvas: HTMLCanvasElement): WebGLRenderingContext {
-  const gl = canvas.getContext("webgl", { antialias: false, premultipliedAlpha: true });
-  if (!gl) throw new Error("WebGL is not supported in this browser");
-  return gl;
+export interface GLContext {
+  /**
+   * The actual rendering context. Typed as the WebGL1 base since that's the
+   * narrowest API that satisfies all callers; the `isWebGL2` flag tells the
+   * caller whether they can rely on WebGL2-only features (integer textures,
+   * GLSL ES 3.00) downstream.
+   */
+  gl: WebGLRenderingContext;
+  isWebGL2: boolean;
+}
+
+/**
+ * Try WebGL2 first so we can exercise integer textures (uint16 ndarrays);
+ * fall back to WebGL1 if unavailable. The caller must consult `isWebGL2`
+ * before sampling integer textures.
+ */
+export function getGL(canvas: HTMLCanvasElement): GLContext {
+  const opts: WebGLContextAttributes = { antialias: false, premultipliedAlpha: true };
+  const gl2 = canvas.getContext("webgl2", opts);
+  if (gl2) return { gl: gl2 as unknown as WebGLRenderingContext, isWebGL2: true };
+  const gl1 = canvas.getContext("webgl", opts);
+  if (gl1) return { gl: gl1, isWebGL2: false };
+  throw new Error("WebGL is not supported in this browser");
 }
 
 function compileShader(gl: WebGLRenderingContext, type: number, source: string): WebGLShader {
@@ -51,7 +70,21 @@ export function createFullscreenQuad(gl: WebGLRenderingContext, attribLocation: 
   gl.vertexAttribPointer(attribLocation, 2, gl.FLOAT, false, 0, 0);
 }
 
-export const VERT_SRC = `
+// ---- Shader sources -------------------------------------------------------
+//
+// Two variants: WebGL1 (GLSL ES 1.00) lays out a 2x2 grid; WebGL2 (GLSL ES 3.00)
+// lays out a 3x2 grid that adds the uint16 ndarray quadrant sampled through a
+// `usampler2D` and its uint8-downcast neighbour for visual comparison.
+//
+// Cell layout (UV origin = bottom-left):
+//   WebGL1 2x2:                WebGL2 3x2:
+//     +--------+--------+        +--------+--------+--------+
+//     | canvas | image  |        | canvas | image  | video  |
+//     +--------+--------+        +--------+--------+--------+
+//     | video  | uint8  |        | uint8  | uint16 | info   |
+//     +--------+--------+        +--------+--------+--------+
+
+export const VERT_SRC_GL1 = `
 attribute vec2 a_position;
 varying vec2 v_uv;
 void main() {
@@ -60,7 +93,7 @@ void main() {
 }
 `;
 
-export const FRAG_SRC = `
+export const FRAG_SRC_GL1 = `
 precision mediump float;
 varying vec2 v_uv;
 uniform sampler2D u_canvas;
@@ -68,7 +101,6 @@ uniform sampler2D u_image;
 uniform sampler2D u_video;
 uniform sampler2D u_ndarray;
 void main() {
-  // 2x2 grid: (0,0) bottom-left, (1,1) top-right (WebGL UV origin = bottom-left).
   vec2 cell = v_uv * 2.0;
   vec2 local = fract(cell);
   bool top = cell.y > 1.0;
@@ -84,5 +116,53 @@ void main() {
     color = texture2D(u_ndarray, local);
   }
   gl_FragColor = color;
+}
+`;
+
+export const VERT_SRC_GL2 = `#version 300 es
+in vec2 a_position;
+out vec2 v_uv;
+void main() {
+  v_uv = a_position * 0.5 + 0.5;
+  gl_Position = vec4(a_position, 0.0, 1.0);
+}
+`;
+
+// 3x2 grid. The uint16 cell samples a `usampler2D` and divides by 65535.0 to
+// get a normalized float, demonstrating the WebGL2 integer-texture path. The
+// bottom-right `info` cell is rendered as a flat dark colour (the sidebar
+// carries the actual info text).
+export const FRAG_SRC_GL2 = `#version 300 es
+precision highp float;
+precision highp int;
+precision highp usampler2D;
+in vec2 v_uv;
+uniform sampler2D u_canvas;
+uniform sampler2D u_image;
+uniform sampler2D u_video;
+uniform sampler2D u_uint8;
+uniform usampler2D u_uint16;
+out vec4 fragColor;
+void main() {
+  vec2 cell = v_uv * vec2(3.0, 2.0);
+  vec2 local = fract(cell);
+  int col = int(floor(cell.x));
+  bool top = cell.y > 1.0;
+  vec4 color;
+  if (top && col == 0) {
+    color = texture(u_canvas, local);
+  } else if (top && col == 1) {
+    color = texture(u_image, local);
+  } else if (top && col == 2) {
+    color = texture(u_video, local);
+  } else if (!top && col == 0) {
+    color = texture(u_uint8, local);
+  } else if (!top && col == 1) {
+    color = vec4(texture(u_uint16, local)) / 65535.0;
+  } else {
+    // Info cell: a subtle dark panel so it reads as "no texture here".
+    color = vec4(0.06, 0.07, 0.10, 1.0);
+  }
+  fragColor = color;
 }
 `;

--- a/apps/example-web/src/main.ts
+++ b/apps/example-web/src/main.ts
@@ -5,12 +5,31 @@ import "webgltexture-loader-ndarray";
 import { LoaderResolver, type WebGLTextureLoader } from "webgltexture-loader";
 import type { NdArray } from "ndarray";
 
-import { createFullscreenQuad, createProgram, FRAG_SRC, getGL, VERT_SRC } from "./gl.js";
-import { makeCanvasSource, makeImageURL, makeNdArray, makeVideo } from "./sources.js";
+import {
+  createFullscreenQuad,
+  createProgram,
+  FRAG_SRC_GL1,
+  FRAG_SRC_GL2,
+  getGL,
+  VERT_SRC_GL1,
+  VERT_SRC_GL2,
+} from "./gl.js";
+import {
+  makeCanvasSource,
+  makeImageURL,
+  makeNdArray,
+  makeUint16Gradient,
+  makeVideo,
+} from "./sources.js";
 
 type Status = "loading" | "loaded" | "failed" | "disposed";
 
-type SourceInput = HTMLCanvasElement | HTMLVideoElement | string | NdArray<Uint8Array>;
+type SourceInput =
+  | HTMLCanvasElement
+  | HTMLVideoElement
+  | string
+  | NdArray<Uint8Array>
+  | NdArray<Uint16Array>;
 
 interface Source {
   readonly name: string;
@@ -20,6 +39,13 @@ interface Source {
   readonly textureUnit: number;
   /** Whether this source mutates over time and needs `update()` every frame. */
   readonly live: boolean;
+  /**
+   * Whether the underlying texture is a WebGL2 integer texture (uint16 etc.).
+   * Such textures must use NEAREST filtering — most GPUs reject LINEAR for
+   * integer internalformats, and the bound `usampler2D` returns `uvec4` so
+   * filtering would have nothing meaningful to interpolate.
+   */
+  readonly integerTexture?: boolean;
   /**
    * Optional promise that rejects to signal the input cannot become ready
    * (e.g. video errored or timed out). Raced against `loader.load()` so the
@@ -53,12 +79,27 @@ function need<T extends HTMLElement>(id: string): T {
 const canvasEl = need<HTMLCanvasElement>("gl");
 const sourcesEl = need<HTMLUListElement>("sources");
 const disposeBtn = need<HTMLButtonElement>("dispose");
+const glVersionEl = need<HTMLSpanElement>("gl-version");
+const noteEl = need<HTMLParagraphElement>("note");
 
-const gl = getGL(canvasEl);
+const { gl, isWebGL2 } = getGL(canvasEl);
+glVersionEl.textContent = isWebGL2 ? "WebGL2" : "WebGL1";
+glVersionEl.className = isWebGL2 ? "pill ok" : "pill warn";
+noteEl.textContent = isWebGL2
+  ? "Bottom row: same gradient rendered as Uint8 (left) vs Uint16 (mid). The dark end of Uint8 shows visible banding because the gamma ramp under-utilises the 8-bit code space."
+  : "WebGL2 unavailable: showing the 2x2 fallback grid. The Uint16 ndarray cell needs WebGL2 integer textures.";
+// Match canvas aspect to the grid so each cell stays square: 3:2 for
+// WebGL2's 3x2 layout, 1:1 for the WebGL1 2x2 fallback.
+document.documentElement.style.setProperty("--aspect", isWebGL2 ? "1.5" : "1");
 const resolver = new LoaderResolver(gl);
 
 const { video, failed: videoFailed, cancelTimeout: cancelVideoTimeout } = makeVideo(VIDEO_URL);
+const { uint16: ndUint16, uint8: ndUint16AsUint8 } = makeUint16Gradient();
 
+// Texture units are assigned by demo-grid position so the uniform map below is
+// stable across the WebGL1 / WebGL2 layouts. The WebGL2 fragment shader
+// references `u_uint16` (a usampler2D); on WebGL1 we render only the 2x2
+// subset (canvas/image/video/ndarray-uint8) and skip the integer cell.
 const sources: Source[] = [
   {
     name: "HTMLCanvasElement",
@@ -72,7 +113,7 @@ const sources: Source[] = [
   },
   {
     name: "Image URL (data:)",
-    position: "top-right",
+    position: isWebGL2 ? "top-mid" : "top-right",
     uniform: "u_image",
     input: makeImageURL(),
     textureUnit: 1,
@@ -82,7 +123,7 @@ const sources: Source[] = [
   },
   {
     name: "HTMLVideoElement",
-    position: "bottom-left",
+    position: isWebGL2 ? "top-right" : "bottom-left",
     uniform: "u_video",
     input: video,
     textureUnit: 2,
@@ -93,10 +134,16 @@ const sources: Source[] = [
     status: "loading",
   },
   {
-    name: "ndarray (RGBA Uint8)",
-    position: "bottom-right",
-    uniform: "u_ndarray",
-    input: makeNdArray(),
+    name: isWebGL2 ? "ndarray (RGBA Uint8, downcast from Uint16)" : "ndarray (RGBA Uint8, plasma)",
+    position: isWebGL2 ? "bottom-left" : "bottom-right",
+    // Slot maps to `u_ndarray` on WebGL1 (existing 2x2 grid) and `u_uint8`
+    // on WebGL2 (precision-comparison cell). The fragment shader picks the
+    // matching uniform name; the unused name simply doesn't get a location.
+    uniform: isWebGL2 ? "u_uint8" : "u_ndarray",
+    // On WebGL2 use the uint8-downcast of the gradient so the bottom row
+    // pairs with the uint16 cell for a direct precision comparison; on
+    // WebGL1 keep the legacy plasma since there's nothing to compare to.
+    input: isWebGL2 ? ndUint16AsUint8 : makeNdArray(),
     textureUnit: 3,
     live: false,
     paramsSet: false,
@@ -104,7 +151,25 @@ const sources: Source[] = [
   },
 ];
 
-const program = createProgram(gl, VERT_SRC, FRAG_SRC);
+if (isWebGL2) {
+  sources.push({
+    name: "ndarray (RGBA Uint16, integer texture)",
+    position: "bottom-mid",
+    uniform: "u_uint16",
+    input: ndUint16,
+    textureUnit: 4,
+    live: false,
+    integerTexture: true,
+    paramsSet: false,
+    status: "loading",
+  });
+}
+
+const program = createProgram(
+  gl,
+  isWebGL2 ? VERT_SRC_GL2 : VERT_SRC_GL1,
+  isWebGL2 ? FRAG_SRC_GL2 : FRAG_SRC_GL1,
+);
 gl.useProgram(program);
 createFullscreenQuad(gl, gl.getAttribLocation(program, "a_position"));
 for (const s of sources) {
@@ -163,8 +228,11 @@ function bindAndUpdate(s: Source): boolean {
   // uploaded once by the loader's first `get()` call.
   if (s.live) s.loader.update(s.input);
   if (!s.paramsSet) {
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    // Integer textures (e.g. RGBA16UI) reject LINEAR filtering on every
+    // mainstream WebGL2 implementation; force NEAREST for that path.
+    const filter = s.integerTexture ? gl.NEAREST : gl.LINEAR;
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, filter);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, filter);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
     s.paramsSet = true;

--- a/apps/example-web/src/sources.ts
+++ b/apps/example-web/src/sources.ts
@@ -148,3 +148,47 @@ export function makeNdArray(): NdArray<Uint8Array> {
   }
   return ndarray(data, [size, size, 4]);
 }
+
+/**
+ * Build a 256x256 RGBA gradient using the full uint16 range with a steep gamma
+ * curve, so the precision difference between uint16 and uint8 is visible at
+ * the dark end (subtle banding when the same data is downcast to 8-bit).
+ *
+ * Returns both the uint16 source and an 8-bit copy (`value >> 8`) of the same
+ * gradient for side-by-side comparison.
+ */
+export function makeUint16Gradient(): {
+  uint16: NdArray<Uint16Array>;
+  uint8: NdArray<Uint8Array>;
+} {
+  const size = 256;
+  const u16 = new Uint16Array(size * size * 4);
+  const u8 = new Uint8Array(size * size * 4);
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      // Horizontal gamma ramp on R/G/B; the dark end stretches over many
+      // 16-bit codes that all collapse to 0..a few in 8-bit, producing
+      // visible banding in the uint8 quadrant.
+      const t = x / (size - 1);
+      const ramp = Math.round(Math.pow(t, 2.2) * 65535);
+      // Vertical secondary modulation so each channel differs slightly,
+      // making the comparison visually distinct from pure greyscale.
+      const m = Math.round((y / (size - 1)) * 65535);
+      const i = (y * size + x) * 4;
+      u16[i] = ramp;
+      u16[i + 1] = (ramp + m) >>> 1;
+      u16[i + 2] = m;
+      u16[i + 3] = 65535;
+      // High-byte truncation matches what uint16 -> uint8 normalization
+      // would produce after dividing by 65535 and re-quantizing to 255.
+      u8[i] = u16[i]! >> 8;
+      u8[i + 1] = u16[i + 1]! >> 8;
+      u8[i + 2] = u16[i + 2]! >> 8;
+      u8[i + 3] = 255;
+    }
+  }
+  return {
+    uint16: ndarray(u16, [size, size, 4]),
+    uint8: ndarray(u8, [size, size, 4]),
+  };
+}

--- a/packages/webgltexture-loader-ndarray/src/NDArrayTextureLoader.gl.test.ts
+++ b/packages/webgltexture-loader-ndarray/src/NDArrayTextureLoader.gl.test.ts
@@ -110,18 +110,19 @@ describeGL("NDArrayTextureLoader against headless-gl", () => {
   // Integer dtype fallbacks under WebGL1.
   // headless-gl is WebGL1 only, so the WebGL2 integer texture paths
   // (R16UI, RG16UI, ...) cannot be exercised in CI. We only cover the
-  // uint8 fallback and the one-time console.warn behavior here.
-  // We isolate the module to reset the per-process warned-dtype memoization
-  // between tests.
+  // uint8 fallback + one-time console.warn behavior here.
+  //
+  // We isolate `drawNDArrayTexture` (not the loader) so each test gets a
+  // fresh `warnedFallbackDtypes` Set without re-running
+  // `NDArrayTextureLoader.ts`'s side-effectful `globalRegistry.add(...)` call,
+  // which would accumulate duplicate registrations across the test process.
   describe("integer dtype fallback (WebGL1)", () => {
     let warnSpy: jest.SpyInstance;
-    let LoaderCtor: typeof NDArrayTextureLoader;
-    let nd: typeof ndarray;
+    let drawFn: typeof import("./drawNDArrayTexture.js").default;
 
     beforeEach(() => {
       jest.isolateModules(() => {
-        LoaderCtor = require("./NDArrayTextureLoader.js").default;
-        nd = require("ndarray");
+        drawFn = require("./drawNDArrayTexture.js").default;
       });
       warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
     });
@@ -130,27 +131,32 @@ describeGL("NDArrayTextureLoader against headless-gl", () => {
       warnSpy.mockRestore();
     });
 
+    function uploadIntegerDtype(arr: ReturnType<typeof ndarray>): WebGLTexture {
+      const tex = gl.createTexture();
+      if (!tex) throw new Error("createTexture failed");
+      gl.bindTexture(gl.TEXTURE_2D, tex);
+      drawFn(gl, arr, false);
+      return tex;
+    }
+
     test("uint16 ndarray on WebGL1 warns once and creates a fallback texture", () => {
-      const loader = new LoaderCtor(gl);
       const data = new Uint16Array([1, 2, 3, 4]);
-      const arr = nd(data, [2, 2]);
-      const result = loader.get(arr);
-      expect(result.width).toBe(2);
-      expect(result.height).toBe(2);
-      expect(gl.isTexture(result.texture)).toBe(true);
+      const arr = ndarray(data, [2, 2]);
+      const tex = uploadIntegerDtype(arr);
+      expect(gl.isTexture(tex)).toBe(true);
       expect(warnSpy).toHaveBeenCalledTimes(1);
       expect(warnSpy.mock.calls[0][0]).toMatch(/uint16/);
-      loader.dispose();
+      gl.deleteTexture(tex);
     });
 
     test("loading the same dtype twice only warns once", () => {
-      const loader = new LoaderCtor(gl);
-      const a = nd(new Uint16Array([1, 2, 3, 4]), [2, 2]);
-      const b = nd(new Uint16Array([5, 6, 7, 8]), [2, 2]);
-      loader.get(a);
-      loader.get(b);
+      const a = ndarray(new Uint16Array([1, 2, 3, 4]), [2, 2]);
+      const b = ndarray(new Uint16Array([5, 6, 7, 8]), [2, 2]);
+      const ta = uploadIntegerDtype(a);
+      const tb = uploadIntegerDtype(b);
       expect(warnSpy).toHaveBeenCalledTimes(1);
-      loader.dispose();
+      gl.deleteTexture(ta);
+      gl.deleteTexture(tb);
     });
   });
 });

--- a/packages/webgltexture-loader-ndarray/src/NDArrayTextureLoader.gl.test.ts
+++ b/packages/webgltexture-loader-ndarray/src/NDArrayTextureLoader.gl.test.ts
@@ -106,4 +106,51 @@ describeGL("NDArrayTextureLoader against headless-gl", () => {
     expect(() => loader.get(arr)).toThrow(/Invalid texture size/);
     loader.dispose();
   });
+
+  // Integer dtype fallbacks under WebGL1.
+  // headless-gl is WebGL1 only, so the WebGL2 integer texture paths
+  // (R16UI, RG16UI, ...) cannot be exercised in CI. We only cover the
+  // uint8 fallback and the one-time console.warn behavior here.
+  // We isolate the module to reset the per-process warned-dtype memoization
+  // between tests.
+  describe("integer dtype fallback (WebGL1)", () => {
+    let warnSpy: jest.SpyInstance;
+    let LoaderCtor: typeof NDArrayTextureLoader;
+    let nd: typeof ndarray;
+
+    beforeEach(() => {
+      jest.isolateModules(() => {
+        LoaderCtor = require("./NDArrayTextureLoader.js").default;
+        nd = require("ndarray");
+      });
+      warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    test("uint16 ndarray on WebGL1 warns once and creates a fallback texture", () => {
+      const loader = new LoaderCtor(gl);
+      const data = new Uint16Array([1, 2, 3, 4]);
+      const arr = nd(data, [2, 2]);
+      const result = loader.get(arr);
+      expect(result.width).toBe(2);
+      expect(result.height).toBe(2);
+      expect(gl.isTexture(result.texture)).toBe(true);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toMatch(/uint16/);
+      loader.dispose();
+    });
+
+    test("loading the same dtype twice only warns once", () => {
+      const loader = new LoaderCtor(gl);
+      const a = nd(new Uint16Array([1, 2, 3, 4]), [2, 2]);
+      const b = nd(new Uint16Array([5, 6, 7, 8]), [2, 2]);
+      loader.get(a);
+      loader.get(b);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      loader.dispose();
+    });
+  });
 });

--- a/packages/webgltexture-loader-ndarray/src/drawNDArrayTexture.test.ts
+++ b/packages/webgltexture-loader-ndarray/src/drawNDArrayTexture.test.ts
@@ -170,6 +170,30 @@ describe("drawNDArrayTexture WebGL2 integer paths (mocked context)", () => {
     expect(upload.type).toBe(expected.UNSIGNED_SHORT);
   });
 
+  // WebGL2 has no `texImage2D` combination that pairs LUMINANCE / ALPHA /
+  // LUMINANCE_ALPHA with FLOAT. Without a guard we'd happily call
+  // texImage2D(..., LUMINANCE, FLOAT, ...) and trip INVALID_ENUM. Confirm
+  // float 2D and float 1-/2-channel 3D shapes get downgraded to UNSIGNED_BYTE.
+  test("2D float ndarray on WebGL2 is downgraded to UNSIGNED_BYTE", () => {
+    const { gl, texImage2D } = makeMockWebGL2();
+    const arr = ndarray(new Float32Array(4), [2, 2]);
+    drawNDArrayTexture(gl, arr, true);
+    const upload = lastUpload(texImage2D);
+    const expected = gl as unknown as Record<string, number>;
+    expect(upload.type).toBe(expected.UNSIGNED_BYTE);
+    expect(upload.format).toBe(expected.LUMINANCE);
+  });
+
+  test("3D float 1-channel ndarray on WebGL2 is downgraded to UNSIGNED_BYTE", () => {
+    const { gl, texImage2D } = makeMockWebGL2();
+    const arr = ndarray(new Float32Array(4), [2, 2, 1]);
+    drawNDArrayTexture(gl, arr, true);
+    const upload = lastUpload(texImage2D);
+    const expected = gl as unknown as Record<string, number>;
+    expect(upload.type).toBe(expected.UNSIGNED_BYTE);
+    expect(upload.format).toBe(expected.ALPHA);
+  });
+
   // The function saves/restores UNPACK_ALIGNMENT to 1 around the upload so
   // odd row byte sizes (frequent for integer dtypes) don't get corrupted.
   test("UNPACK_ALIGNMENT is set to 1 then restored to its previous value", () => {

--- a/packages/webgltexture-loader-ndarray/src/drawNDArrayTexture.test.ts
+++ b/packages/webgltexture-loader-ndarray/src/drawNDArrayTexture.test.ts
@@ -44,7 +44,7 @@ function makeMockWebGL2(): {
     RGBA16UI: 0x8d76,
     R16I: 0x8233,
     RG16I: 0x8239,
-    RGB16I: 0x8d8f,
+    RGB16I: 0x8d89,
     RGBA16I: 0x8d88,
     R32UI: 0x8236,
     RG32UI: 0x823c,

--- a/packages/webgltexture-loader-ndarray/src/drawNDArrayTexture.test.ts
+++ b/packages/webgltexture-loader-ndarray/src/drawNDArrayTexture.test.ts
@@ -1,0 +1,189 @@
+import ndarray from "ndarray";
+import drawNDArrayTexture from "./drawNDArrayTexture.js";
+
+/**
+ * Mock the slice of WebGL2 the integer-texture path actually touches:
+ *   - the WebGL1 enums it inherits (UNSIGNED_BYTE, FLOAT, RGBA, ALPHA, ...)
+ *   - the WebGL2-only enums it probes (R16UI etc.) and reads via gl[name]
+ *   - getParameter(MAX_TEXTURE_SIZE | UNPACK_ALIGNMENT)
+ *   - pixelStorei (for UNPACK_ALIGNMENT save/restore)
+ *   - texImage2D — the only call we want to assert on
+ *
+ * `R16UI` being a number is what triggers the WebGL2 path
+ * (see `isWebGL2Context` in drawNDArrayTexture.ts).
+ */
+function makeMockWebGL2(): {
+  gl: WebGLRenderingContext;
+  texImage2D: jest.Mock;
+} {
+  const ENUMS: Record<string, number> = {
+    // WebGL1 enums actually referenced by the function.
+    UNSIGNED_BYTE: 0x1401,
+    BYTE: 0x1400,
+    SHORT: 0x1402,
+    UNSIGNED_SHORT: 0x1403,
+    INT: 0x1404,
+    UNSIGNED_INT: 0x1405,
+    FLOAT: 0x1406,
+    ALPHA: 0x1906,
+    RGB: 0x1907,
+    RGBA: 0x1908,
+    LUMINANCE: 0x1909,
+    LUMINANCE_ALPHA: 0x190a,
+    TEXTURE_2D: 0x0de1,
+    MAX_TEXTURE_SIZE: 0x0d33,
+    UNPACK_ALIGNMENT: 0x0cf5,
+    // WebGL2-only constants the integer path resolves by name.
+    RED_INTEGER: 0x8d94,
+    RG_INTEGER: 0x8228,
+    RGB_INTEGER: 0x8d98,
+    RGBA_INTEGER: 0x8d99,
+    R16UI: 0x8234,
+    RG16UI: 0x823a,
+    RGB16UI: 0x8d77,
+    RGBA16UI: 0x8d76,
+    R16I: 0x8233,
+    RG16I: 0x8239,
+    RGB16I: 0x8d8f,
+    RGBA16I: 0x8d88,
+    R32UI: 0x8236,
+    RG32UI: 0x823c,
+    RGB32UI: 0x8d71,
+    RGBA32UI: 0x8d70,
+    R32I: 0x8235,
+    RG32I: 0x823b,
+    RGB32I: 0x8d83,
+    RGBA32I: 0x8d82,
+    R8I: 0x8231,
+    RG8I: 0x8237,
+    RGB8I: 0x8d8f,
+    RGBA8I: 0x8d8e,
+    RGB32F: 0x8815,
+    RGBA32F: 0x8814,
+  };
+  const texImage2D = jest.fn();
+  const gl = {
+    ...ENUMS,
+    getParameter: (name: number): number => {
+      if (name === ENUMS.MAX_TEXTURE_SIZE) return 4096;
+      if (name === ENUMS.UNPACK_ALIGNMENT) return 4;
+      throw new Error("unexpected getParameter " + name);
+    },
+    pixelStorei: jest.fn(),
+    texImage2D,
+  };
+  return { gl: gl as unknown as WebGLRenderingContext, texImage2D };
+}
+
+interface UploadCall {
+  internalformat: number;
+  format: number;
+  type: number;
+  width: number;
+  height: number;
+  buffer: ArrayBufferView;
+}
+
+function lastUpload(texImage2D: jest.Mock): UploadCall {
+  const call = texImage2D.mock.calls.at(-1);
+  if (!call) throw new Error("texImage2D was not called");
+  // texImage2D(target, level, internalformat, width, height, border, format, type, pixels)
+  return {
+    internalformat: call[2],
+    width: call[3],
+    height: call[4],
+    format: call[6],
+    type: call[7],
+    buffer: call[8],
+  };
+}
+
+describe("drawNDArrayTexture WebGL2 integer paths (mocked context)", () => {
+  // Each row: [dtype, expected internalformat enum name, expected GL type enum name, ctor].
+  const cases: Array<{
+    dtype: "uint16" | "int16" | "uint32" | "int32" | "int8";
+    internalformatName: string;
+    typeName: string;
+    Ctor:
+      | typeof Uint16Array
+      | typeof Int16Array
+      | typeof Uint32Array
+      | typeof Int32Array
+      | typeof Int8Array;
+  }> = [
+    {
+      dtype: "uint16",
+      internalformatName: "RGBA16UI",
+      typeName: "UNSIGNED_SHORT",
+      Ctor: Uint16Array,
+    },
+    { dtype: "int16", internalformatName: "RGBA16I", typeName: "SHORT", Ctor: Int16Array },
+    {
+      dtype: "uint32",
+      internalformatName: "RGBA32UI",
+      typeName: "UNSIGNED_INT",
+      Ctor: Uint32Array,
+    },
+    { dtype: "int32", internalformatName: "RGBA32I", typeName: "INT", Ctor: Int32Array },
+    { dtype: "int8", internalformatName: "RGBA8I", typeName: "BYTE", Ctor: Int8Array },
+  ];
+
+  for (const { dtype, internalformatName, typeName, Ctor } of cases) {
+    test(`${dtype} RGBA -> RGBA_INTEGER + ${internalformatName} + ${typeName}`, () => {
+      const { gl, texImage2D } = makeMockWebGL2();
+      const data = new Ctor(2 * 2 * 4);
+      const arr = ndarray(data as unknown as ArrayLike<number>, [2, 2, 4]);
+      drawNDArrayTexture(gl, arr, false);
+      const upload = lastUpload(texImage2D);
+      const expected = gl as unknown as Record<string, number>;
+      expect(upload.format).toBe(expected.RGBA_INTEGER);
+      expect(upload.internalformat).toBe(expected[internalformatName]);
+      expect(upload.type).toBe(expected[typeName]);
+      expect(upload.width).toBe(2);
+      expect(upload.height).toBe(2);
+    });
+  }
+
+  // Non-RGBA channel counts dispatch through the same integer table; spot-check
+  // a 2-channel uint16 to make sure the per-channel internalformat lookup picks
+  // RG16UI (not RGBA16UI) and the format is RG_INTEGER (not RGBA_INTEGER).
+  test("uint16 2-channel -> RG_INTEGER + RG16UI + UNSIGNED_SHORT", () => {
+    const { gl, texImage2D } = makeMockWebGL2();
+    const arr = ndarray(new Uint16Array(2 * 2 * 2), [2, 2, 2]);
+    drawNDArrayTexture(gl, arr, false);
+    const upload = lastUpload(texImage2D);
+    const expected = gl as unknown as Record<string, number>;
+    expect(upload.format).toBe(expected.RG_INTEGER);
+    expect(upload.internalformat).toBe(expected.RG16UI);
+    expect(upload.type).toBe(expected.UNSIGNED_SHORT);
+  });
+
+  // 2D shapes get treated as a single-channel R*I/R*UI texture.
+  test("uint16 2D shape -> RED_INTEGER + R16UI + UNSIGNED_SHORT", () => {
+    const { gl, texImage2D } = makeMockWebGL2();
+    const arr = ndarray(new Uint16Array(2 * 2), [2, 2]);
+    drawNDArrayTexture(gl, arr, false);
+    const upload = lastUpload(texImage2D);
+    const expected = gl as unknown as Record<string, number>;
+    expect(upload.format).toBe(expected.RED_INTEGER);
+    expect(upload.internalformat).toBe(expected.R16UI);
+    expect(upload.type).toBe(expected.UNSIGNED_SHORT);
+  });
+
+  // The function saves/restores UNPACK_ALIGNMENT to 1 around the upload so
+  // odd row byte sizes (frequent for integer dtypes) don't get corrupted.
+  test("UNPACK_ALIGNMENT is set to 1 then restored to its previous value", () => {
+    const { gl } = makeMockWebGL2();
+    const pixelStorei = (gl as unknown as { pixelStorei: jest.Mock }).pixelStorei;
+    const arr = ndarray(new Uint16Array(2 * 2 * 4), [2, 2, 4]);
+    drawNDArrayTexture(gl, arr, false);
+    expect(pixelStorei).toHaveBeenCalledWith(
+      (gl as unknown as Record<string, number>).UNPACK_ALIGNMENT,
+      1,
+    );
+    expect(pixelStorei).toHaveBeenLastCalledWith(
+      (gl as unknown as Record<string, number>).UNPACK_ALIGNMENT,
+      4,
+    );
+  });
+});

--- a/packages/webgltexture-loader-ndarray/src/drawNDArrayTexture.ts
+++ b/packages/webgltexture-loader-ndarray/src/drawNDArrayTexture.ts
@@ -42,6 +42,15 @@ interface IntegerDtypeEntry {
   typeName: string;
 }
 
+// Per-channel-count `format` constants for integer textures (1..4 channels).
+// Hoisted to module scope so we don't reallocate this array on every draw.
+const INTEGER_FORMAT_NAMES: readonly [string, string, string, string] = [
+  "RED_INTEGER",
+  "RG_INTEGER",
+  "RGB_INTEGER",
+  "RGBA_INTEGER",
+];
+
 const INTEGER_DTYPE_TABLE: Record<IntegerDtypeKind, IntegerDtypeEntry> = {
   uint16: {
     internalformatNames: ["R16UI", "RG16UI", "RGB16UI", "RGBA16UI"],
@@ -166,8 +175,7 @@ export default function drawNDArrayTexture(
       if (channelIndex < 0 || channelIndex > 3) {
         throw new Error("webgltexture-loader-ndarray: Invalid shape for pixel coords");
       }
-      const integerFormatNames = ["RED_INTEGER", "RG_INTEGER", "RGB_INTEGER", "RGBA_INTEGER"];
-      format = gl2Const(gl, integerFormatNames[channelIndex]);
+      format = gl2Const(gl, INTEGER_FORMAT_NAMES[channelIndex]);
       internalformat = gl2Const(
         gl,
         INTEGER_DTYPE_TABLE[integerKind].internalformatNames[channelIndex],

--- a/packages/webgltexture-loader-ndarray/src/drawNDArrayTexture.ts
+++ b/packages/webgltexture-loader-ndarray/src/drawNDArrayTexture.ts
@@ -147,9 +147,17 @@ export default function drawNDArrayTexture(
   // Resolve final `type` before picking internalformat: on WebGL2 the
   // internalformat must match the data type (e.g. RGB32F requires FLOAT,
   // not UNSIGNED_BYTE), so we need the post-fallback `type` here.
-  // ALPHA / LUMINANCE_ALPHA have no usable float internalformat on WebGL2,
-  // so we force the uint8 path for those shapes when running on WebGL2.
-  if (!isWebGL1 && type === gl.FLOAT && shape.length === 3 && (shape[2] === 1 || shape[2] === 2)) {
+  //
+  // Single- and two-channel shapes get mapped to LUMINANCE / ALPHA /
+  // LUMINANCE_ALPHA below. WebGL2 has no FLOAT-typed combination valid
+  // with those legacy formats (the spec table only lists UNSIGNED_BYTE),
+  // so force the uint8 fallback for them when running on WebGL2. This
+  // covers both 2D shapes (single channel) and 3D shapes with 1–2 channels.
+  if (
+    !isWebGL1 &&
+    type === gl.FLOAT &&
+    (shape.length === 2 || (shape.length === 3 && (shape[2] === 1 || shape[2] === 2)))
+  ) {
     floatSupported = false;
   }
   if (type === gl.FLOAT && !floatSupported) {

--- a/packages/webgltexture-loader-ndarray/src/drawNDArrayTexture.ts
+++ b/packages/webgltexture-loader-ndarray/src/drawNDArrayTexture.ts
@@ -20,13 +20,84 @@ function convertFloatToUint8(out: NdArray, inp: NdArray): void {
   ops.muls(out, inp, 255.0);
 }
 
+// Memoize per-dtype warnings so we only console.warn once per fallback dtype.
+const warnedFallbackDtypes = new Set<string>();
+function warnIntegerFallback(dtype: string): void {
+  if (warnedFallbackDtypes.has(dtype)) return;
+  warnedFallbackDtypes.add(dtype);
+  console.warn(
+    `webgltexture-loader-ndarray: ndarray dtype "${dtype}" requires WebGL2 integer textures; ` +
+      `falling back to uint8 on this WebGL1 context. Precision will be reduced.`,
+  );
+}
+
+// Lookup table for integer-typed dtypes -> per-channel-count internal formats and gl type.
+// All entries here are WebGL2-only; on WebGL1 we fall back to uint8 with a warning.
+type IntegerDtypeKind = "uint16" | "int16" | "uint32" | "int32" | "int8";
+
+interface IntegerDtypeEntry {
+  // Names of the WebGL2 internalformat constants per channel count: [R, RG, RGB, RGBA].
+  internalformatNames: [string, string, string, string];
+  // Name of the gl.type constant (e.g. "UNSIGNED_SHORT", "SHORT").
+  typeName: string;
+}
+
+const INTEGER_DTYPE_TABLE: Record<IntegerDtypeKind, IntegerDtypeEntry> = {
+  uint16: {
+    internalformatNames: ["R16UI", "RG16UI", "RGB16UI", "RGBA16UI"],
+    typeName: "UNSIGNED_SHORT",
+  },
+  int16: {
+    internalformatNames: ["R16I", "RG16I", "RGB16I", "RGBA16I"],
+    typeName: "SHORT",
+  },
+  uint32: {
+    internalformatNames: ["R32UI", "RG32UI", "RGB32UI", "RGBA32UI"],
+    typeName: "UNSIGNED_INT",
+  },
+  int32: {
+    internalformatNames: ["R32I", "RG32I", "RGB32I", "RGBA32I"],
+    typeName: "INT",
+  },
+  int8: {
+    internalformatNames: ["R8I", "RG8I", "RGB8I", "RGBA8I"],
+    typeName: "BYTE",
+  },
+};
+
+function isIntegerDtype(dtype: string): dtype is IntegerDtypeKind {
+  return (
+    dtype === "uint16" ||
+    dtype === "int16" ||
+    dtype === "uint32" ||
+    dtype === "int32" ||
+    dtype === "int8"
+  );
+}
+
+// Read a numeric constant by name from a WebGL2 context. Casts because the DOM
+// lib types we use are WebGLRenderingContext (WebGL1).
+function gl2Const(gl: WebGLRenderingContext, name: string): number {
+  return (gl as unknown as Record<string, number>)[name];
+}
+
+// Detect WebGL2 reliably across browsers and headless test runners:
+//   - `gl instanceof WebGLRenderingContext` is true for WebGL2 too
+//     (WebGL2RenderingContext extends it), so it can't distinguish.
+//   - `WebGL2RenderingContext` is undefined under headless-gl/Node.
+//   - Some headless WebGL1 backends expose `texStorage2D` as a stub.
+// Probing a WebGL2-only enum that WebGL1 simply doesn't define is the most
+// portable check available.
+function isWebGL2Context(gl: WebGLRenderingContext): boolean {
+  return typeof (gl as unknown as { R16UI?: unknown }).R16UI === "number";
+}
+
 export default function drawNDArrayTexture(
   gl: WebGLRenderingContext,
   array: NdArray,
   floatSupported: boolean,
 ): void {
-  const isWebGL1 =
-    typeof WebGLRenderingContext === "undefined" || gl instanceof WebGLRenderingContext;
+  const isWebGL1 = !isWebGL2Context(gl);
 
   let dtype: string = array.dtype;
   let shape = array.shape.slice();
@@ -35,8 +106,21 @@ export default function drawNDArrayTexture(
     throw new Error("webgltexture-loader-ndarray: Invalid texture size");
   }
   let packed = isPacked(shape, array.stride.slice());
+
+  // Determine whether this dtype should take the WebGL2 integer texture path.
+  const integerKind: IntegerDtypeKind | null = isIntegerDtype(dtype) ? dtype : null;
+  const useIntegerPath = integerKind !== null && !isWebGL1;
+  if (integerKind !== null && isWebGL1) {
+    // WebGL1 has no integer textures; warn once and fall through to the uint8 branch.
+    warnIntegerFallback(integerKind);
+  }
+
   let type = 0;
-  if (dtype === "float32") {
+  if (useIntegerPath && integerKind !== null) {
+    type = gl2Const(gl, INTEGER_DTYPE_TABLE[integerKind].typeName);
+    // `packed` (computed above from stride/offset) already determines whether
+    // we can upload `array.data` directly; only repack when not contiguous.
+  } else if (dtype === "float32") {
     type = gl.FLOAT;
   } else if (dtype === "float64") {
     type = gl.FLOAT;
@@ -45,64 +129,123 @@ export default function drawNDArrayTexture(
   } else if (dtype === "uint8") {
     type = gl.UNSIGNED_BYTE;
   } else {
+    // Unknown / fallback (also the WebGL1 path for integer dtypes).
     type = gl.UNSIGNED_BYTE;
     packed = false;
     dtype = "uint8";
   }
+
+  // Resolve final `type` before picking internalformat: on WebGL2 the
+  // internalformat must match the data type (e.g. RGB32F requires FLOAT,
+  // not UNSIGNED_BYTE), so we need the post-fallback `type` here.
+  // ALPHA / LUMINANCE_ALPHA have no usable float internalformat on WebGL2,
+  // so we force the uint8 path for those shapes when running on WebGL2.
+  if (!isWebGL1 && type === gl.FLOAT && shape.length === 3 && (shape[2] === 1 || shape[2] === 2)) {
+    floatSupported = false;
+  }
+  if (type === gl.FLOAT && !floatSupported) {
+    type = gl.UNSIGNED_BYTE;
+    packed = false;
+  }
+
   let format = 0;
   let internalformat = 0;
   if (shape.length === 2) {
-    internalformat = format = gl.LUMINANCE;
+    if (useIntegerPath && integerKind !== null) {
+      // Treat 2D shapes as single-channel R*I/R*UI integer textures.
+      format = gl2Const(gl, "RED_INTEGER");
+      internalformat = gl2Const(gl, INTEGER_DTYPE_TABLE[integerKind].internalformatNames[0]);
+    } else {
+      internalformat = format = gl.LUMINANCE;
+    }
     shape = [shape[0], shape[1], 1];
     array = ndarray(array.data, shape, [array.stride[0], array.stride[1], 1], array.offset);
   } else if (shape.length === 3) {
-    if (shape[2] === 1) {
+    if (useIntegerPath && integerKind !== null) {
+      const channelIndex = shape[2] - 1;
+      if (channelIndex < 0 || channelIndex > 3) {
+        throw new Error("webgltexture-loader-ndarray: Invalid shape for pixel coords");
+      }
+      const integerFormatNames = ["RED_INTEGER", "RG_INTEGER", "RGB_INTEGER", "RGBA_INTEGER"];
+      format = gl2Const(gl, integerFormatNames[channelIndex]);
+      internalformat = gl2Const(
+        gl,
+        INTEGER_DTYPE_TABLE[integerKind].internalformatNames[channelIndex],
+      );
+    } else if (shape[2] === 1) {
       internalformat = format = gl.ALPHA;
-      // WebGL2 doesn't appear to expose a usable float internalformat for ALPHA;
-      // fall back to uint8.
-      if (!isWebGL1) floatSupported = false;
     } else if (shape[2] === 2) {
       internalformat = format = gl.LUMINANCE_ALPHA;
-      // Same WebGL2 quirk as ALPHA above.
-      if (!isWebGL1) floatSupported = false;
     } else if (shape[2] === 3) {
       format = gl.RGB;
-      internalformat = isWebGL1 ? gl.RGB : (gl as unknown as { RGB32F: number }).RGB32F;
+      internalformat =
+        !isWebGL1 && type === gl.FLOAT ? (gl as unknown as { RGB32F: number }).RGB32F : gl.RGB;
     } else if (shape[2] === 4) {
       format = gl.RGBA;
-      internalformat = isWebGL1 ? gl.RGBA : (gl as unknown as { RGBA32F: number }).RGBA32F;
+      internalformat =
+        !isWebGL1 && type === gl.FLOAT ? (gl as unknown as { RGBA32F: number }).RGBA32F : gl.RGBA;
     } else {
       throw new Error("webgltexture-loader-ndarray: Invalid shape for pixel coords");
     }
   } else {
     throw new Error("webgltexture-loader-ndarray: Invalid shape for texture");
   }
-  if (type === gl.FLOAT && !floatSupported) {
-    type = gl.UNSIGNED_BYTE;
-    packed = false;
-  }
   let buffer: ArrayBufferView;
   const size = array.size;
-  let store: Uint8Array | Float32Array | undefined;
+  let store: ArrayBufferView | undefined;
   if (!packed) {
     const stride = [shape[2], shape[2] * shape[0], 1];
     if ((dtype === "float32" || dtype === "float64") && type === gl.UNSIGNED_BYTE) {
-      store = pool.malloc(size, "uint8") as Uint8Array;
-      const out = ndarray(store, shape, stride, 0);
+      const u8 = pool.malloc(size, "uint8") as Uint8Array;
+      const out = ndarray(u8, shape, stride, 0);
       convertFloatToUint8(out, array);
-    } else {
-      store = pool.malloc(size, dtype as "uint8" | "float32") as Uint8Array | Float32Array;
-      const out = ndarray(store, shape, stride, 0);
+      store = u8;
+      buffer = u8.subarray(0, size);
+    } else if (useIntegerPath && integerKind !== null) {
+      const typed = pool.malloc(size, integerKind) as unknown as
+        | Uint16Array
+        | Int16Array
+        | Uint32Array
+        | Int32Array
+        | Int8Array;
+      const out = ndarray(typed, shape, stride, 0);
       ops.assign(out, array);
+      store = typed;
+      buffer = typed.subarray(0, size);
+    } else {
+      const typed = pool.malloc(size, dtype as "uint8" | "float32") as Uint8Array | Float32Array;
+      const out = ndarray(typed, shape, stride, 0);
+      ops.assign(out, array);
+      store = typed;
+      buffer = typed.subarray(0, size);
     }
-    buffer = store.subarray(0, size);
   } else if (array.offset === 0 && array.data.length === size) {
     buffer = array.data as ArrayBufferView;
   } else {
     buffer = (array.data as Uint8Array).subarray(array.offset, array.offset + size);
   }
-  gl.texImage2D(gl.TEXTURE_2D, 0, internalformat, shape[0], shape[1], 0, format, type, buffer);
-  if (store) {
-    pool.free(store);
+  // Row byte sizes for the new integer dtypes (and for RGB/uint8 at odd widths)
+  // are not always multiples of the default UNPACK_ALIGNMENT of 4, which can
+  // corrupt uploads. Set alignment to 1 around the upload and restore after,
+  // using try/finally so a thrown texImage2D doesn't leak the alignment.
+  const prevAlignment = gl.getParameter(gl.UNPACK_ALIGNMENT);
+  if (prevAlignment !== 1) gl.pixelStorei(gl.UNPACK_ALIGNMENT, 1);
+  try {
+    gl.texImage2D(
+      gl.TEXTURE_2D,
+      0,
+      internalformat,
+      shape[0],
+      shape[1],
+      0,
+      format,
+      type,
+      buffer as ArrayBufferView,
+    );
+  } finally {
+    if (prevAlignment !== 1) gl.pixelStorei(gl.UNPACK_ALIGNMENT, prevAlignment);
+    if (store) {
+      pool.free(store);
+    }
   }
 }

--- a/packages/webgltexture-loader-ndarray/src/types.d.ts
+++ b/packages/webgltexture-loader-ndarray/src/types.d.ts
@@ -10,7 +10,18 @@ declare module "ndarray-ops" {
 declare module "typedarray-pool" {
   type DType = "uint8" | "uint16" | "uint32" | "int8" | "int16" | "int32" | "float32" | "float64";
   const pool: {
-    malloc(size: number, dtype: DType): Uint8Array | Float32Array;
+    malloc(
+      size: number,
+      dtype: DType,
+    ):
+      | Uint8Array
+      | Uint16Array
+      | Uint32Array
+      | Int8Array
+      | Int16Array
+      | Int32Array
+      | Float32Array
+      | Float64Array;
     free(buf: ArrayBufferView): void;
   };
   export default pool;


### PR DESCRIPTION
Closes #22.

## Why

`drawNDArrayTexture` previously recognized only `float32`/`float64` (→ `gl.FLOAT`) and `uint8` (→ `gl.UNSIGNED_BYTE`); every other ndarray dtype was silently coerced to `uint8`, destroying useful precision (medical imaging, heightmaps, scientific data).

## Changes

ndarray dtypes `uint16`, `int16`, `uint32`, `int32`, `int8` now route to **WebGL2 integer internalformats** with the matching `*_INTEGER` format constants and integer gl types:

| dtype | internalformat (per channel) | format | type |
|---|---|---|---|
| `uint16` | `R16UI` / `RG16UI` / `RGB16UI` / `RGBA16UI` | `*_INTEGER` | `UNSIGNED_SHORT` |
| `int16` | `R16I` / `RG16I` / `RGB16I` / `RGBA16I` | `*_INTEGER` | `SHORT` |
| `uint32` | `R32UI` / `RG32UI` / `RGB32UI` / `RGBA32UI` | `*_INTEGER` | `UNSIGNED_INT` |
| `int32` | `R32I` / `RG32I` / `RGB32I` / `RGBA32I` | `*_INTEGER` | `INT` |
| `int8` | `R8I` / `RG8I` / `RGB8I` / `RGBA8I` | `*_INTEGER` | `BYTE` |

On **WebGL1** contexts (no integer texture support), the loader falls back to `uint8` and emits a **one-time `console.warn` per dtype** (memoized in a module-level `Set<string>`).

The existing `uint8` and `float32`/`float64` paths are untouched, including the `convertFloatToUint8` fallback when `floatSupported === false`.

## Visual verification (`apps/example-web`)

The Vite demo is extended to actually exercise the new path so a contributor can confirm it visually in a browser:

- The demo now requests a **WebGL2** context first (falling back to WebGL1).
- On WebGL2 it renders a **3x2 grid**: top row carries the existing canvas/image/video cells; the bottom row pairs the **same 256x256 gamma-ramp gradient** rendered as `Uint8` (downcast `v >> 8`, left) vs. `Uint16` (right, uploaded via the new integer-texture path and sampled through a `usampler2D` divided by `65535.0`). The dark end of the Uint8 cell shows visible banding while the Uint16 cell stays smooth.
- On WebGL1 the demo falls back to the original 2x2 layout and the sidebar pill flips to a yellow `WebGL1` indicator (which also exercises the `console.warn` path if a Uint16 ndarray is loaded).

Run with `corepack yarn workspace example-web dev`.

## Test plan

- [x] `yarn build` (parallel topo) green
- [x] `yarn test`: **10 suites / 39 tests** — adds 8 mocked-WebGL2 tests covering the dtype → (internalformat, format, type) lookup table, plus the WebGL1 fallback warning + memoization tests
- [x] `yarn lint` 0/0
- [x] `yarn format` clean
- [x] `yarn workspace example-web build` green
- [ ] Real WebGL2 paths cannot be exercised in CI (`headless-gl` is WebGL1 only); the mocked-context tests cover the enum table and `UNPACK_ALIGNMENT` save/restore, and the example-web demo is the visual smoke test for the actual GPU upload.