### PR TITLE
Add example-web Vite demo exercising every web-side loader

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -48,3 +48,6 @@ jobs:
       - run: yarn install --immutable
       - run: yarn build
       - run: xvfb-run -s "-ac -screen 0 1280x1024x24" yarn test
+      # Smoke-build the demo app (excluded from `yarn build`'s --no-private
+      # cascade) so demo bitrot is caught against library API changes.
+      - run: yarn workspace example-web build

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ lib/
 coverage/
 .DS_Store
 packages/*/README.md
+apps/*/dist/
 
 # Yarn 4 (Berry) — keep releases/plugins/patches, ignore cache & state
 .yarn/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Project notes
 
 - Yarn 4 is pinned via Corepack (`packageManager` field). If `yarn` is shimmed by `proto` and refuses to run, invoke `corepack yarn ...` instead.
-- Source is TypeScript. Build is per-package `tsc` orchestrated by `yarn workspaces foreach -Apt run build` from the root (parallel topological). Tests are transformed by `ts-jest`.
+- Source is TypeScript. Build is per-package `tsc` orchestrated by `yarn workspaces foreach -Apt --no-private run build` from the root (parallel topological; `--no-private` skips private workspaces such as `apps/example-web`). Tests are transformed by `ts-jest`.
 - Peer-deps for the Expo and React Native loaders are not installed; minimal type stubs live in `packages/*/src/types.d.ts` files. Don't try to install `expo-camera` / `react-native` to type-check — keep the stubs minimal.
 - Lint / format are oxc tools: `yarn lint` (oxlint) and `yarn format` (oxfmt --check) / `yarn format:fix`. `oxfmt` has no config file yet — it uses defaults.
 - Headless GL tests use the `gl` package (`9.0.0-rc.10` for Node 24 compat). They're suffixed `*.gl.test.ts` and skip themselves if `require("gl")` throws (so local macOS without the prebuilt binding still passes the rest of the suite). CI installs `xvfb + mesa` and runs the suite under `xvfb-run`.
+- The visual smoke-test demo lives in `apps/example-web/` (Vite + vanilla TS). It is private (`"private": true`) and therefore excluded from the root `yarn build` cascade by `--no-private` so library builds stay fast; verify it standalone with `corepack yarn workspace example-web build`.

--- a/apps/example-web/README.md
+++ b/apps/example-web/README.md
@@ -1,0 +1,60 @@
+# example-web
+
+Visual smoke test for every web-side `webgltexture-loader` so contributors can
+quickly confirm the lib works end-to-end across all DOM and ndarray sources.
+
+## Run
+
+```bash
+corepack yarn install
+corepack yarn build               # build library packages first (lib/*) so workspace deps resolve
+corepack yarn workspace example-web dev
+```
+
+The Vite dev server prints a local URL (default port `5173`). The `yarn build`
+step is required because the workspace packages (e.g. `webgltexture-loader`)
+declare `main: lib/index.js`, and `lib/` is only produced by their build.
+
+## What it shows
+
+A WebGL canvas split into a 2x2 grid, each quadrant sampling a different
+loader:
+
+| Quadrant     | Loader                       | Source                                   |
+| ------------ | ---------------------------- | ---------------------------------------- |
+| top-left     | `CanvasTextureLoader`        | A programmatic `HTMLCanvasElement` (gradient + circle + label). |
+| top-right    | `ImageURLTextureLoader`      | A `data:image/png` URL generated at runtime (offline-friendly). |
+| bottom-left  | `VideoTextureLoader`         | A CC0 webm streamed from MDN's media bucket (`Access-Control-Allow-Origin: *`, required for `crossOrigin="anonymous"`). |
+| bottom-right | `NDArrayTextureLoader`       | A 64x64 RGBA `Uint8Array` plasma pattern wrapped with `ndarray`. |
+
+The sidebar shows each source's resolved size, the loader class that handled
+it, and a status indicator. The "Dispose all" button calls `resolver.dispose()`
+and freezes the canvas to demonstrate cleanup.
+
+## How it wires the loaders
+
+```ts
+import "webgltexture-loader-dom";   // registers Canvas/ImageURL/Video loaders
+import "webgltexture-loader-ndarray"; // registers NDArrayTextureLoader
+import { LoaderResolver } from "webgltexture-loader";
+
+const resolver = new LoaderResolver(gl);
+const loader = resolver.resolve(input);
+await loader?.load(input);
+loader?.update(input);            // only needed for live sources (e.g. <video>)
+const { texture, width, height } = loader!.get(input)!;
+```
+
+Each frame the render loop calls `update()` only for live sources (the
+`<video>`) so they re-upload their latest frame; static sources are uploaded
+once by the loader's first `get()`.
+
+## Notes
+
+- The video uses `crossOrigin="anonymous"`; if it fails to play in your
+  browser, drop a `sample.mp4` into `apps/example-web/public/` and edit
+  `VIDEO_URL` in `src/main.ts`.
+- The Expo and React Native loaders are intentionally not exercised here —
+  they need a native runtime that can't run in a plain web demo.
+- This app sits outside the library `yarn build` cascade. Run
+  `corepack yarn workspace example-web build` to type-check and bundle it.

--- a/apps/example-web/index.html
+++ b/apps/example-web/index.html
@@ -1,0 +1,136 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>webgltexture-loader · example-web</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #0e1014;
+        --panel: #161a22;
+        --border: #2a2f3a;
+        --text: #e6e8ee;
+        --muted: #8b91a1;
+        --ok: #4caf50;
+        --pending: #f0c419;
+        --err: #ef5350;
+      }
+      * { box-sizing: border-box; }
+      html, body {
+        margin: 0;
+        height: 100%;
+        background: var(--bg);
+        color: var(--text);
+        font: 13px/1.45 system-ui, -apple-system, "Segoe UI", sans-serif;
+      }
+      .layout {
+        display: grid;
+        grid-template-columns: 1fr 320px;
+        height: 100vh;
+      }
+      .stage {
+        position: relative;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #000;
+        overflow: hidden;
+      }
+      #gl {
+        width: min(100%, calc(100vh * 1));
+        height: 100%;
+        display: block;
+      }
+      .sidebar {
+        border-left: 1px solid var(--border);
+        background: var(--panel);
+        padding: 16px;
+        overflow-y: auto;
+      }
+      h1 {
+        font-size: 14px;
+        margin: 0 0 4px;
+        font-weight: 600;
+      }
+      .muted { color: var(--muted); }
+      .sources {
+        list-style: none;
+        margin: 16px 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+      .source {
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 10px 12px;
+      }
+      .source header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+      }
+      .source .name { font-weight: 600; }
+      .source .pos { color: var(--muted); font-size: 11px; }
+      .source dl {
+        margin: 6px 0 0;
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 2px 10px;
+        font-size: 12px;
+      }
+      .source dt { color: var(--muted); }
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+      }
+      .status::before {
+        content: "";
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--muted);
+      }
+      .status.loading::before { background: var(--pending); }
+      .status.loaded::before { background: var(--ok); }
+      .status.failed::before { background: var(--err); }
+      .status.disposed::before { background: var(--muted); }
+      button {
+        background: #2a2f3a;
+        color: var(--text);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 8px 12px;
+        cursor: pointer;
+        font: inherit;
+      }
+      button:hover { background: #353c4a; }
+      button:disabled { opacity: 0.5; cursor: not-allowed; }
+      a { color: #7ab7ff; }
+    </style>
+  </head>
+  <body>
+    <div class="layout">
+      <div class="stage">
+        <canvas id="gl" width="1024" height="1024" aria-label="WebGL output"></canvas>
+      </div>
+      <aside class="sidebar">
+        <h1>webgltexture-loader demo</h1>
+        <div class="muted">Each quadrant samples a different loader.</div>
+        <ul id="sources" class="sources"></ul>
+        <button id="dispose">Dispose all</button>
+        <p class="muted" style="margin-top:16px">
+          Source: <a href="https://github.com/gre/webgltexture-loader">gre/webgltexture-loader</a>
+        </p>
+      </aside>
+    </div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/apps/example-web/package.json
+++ b/apps/example-web/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "example-web",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Visual smoke test for every web-side webgltexture-loader (canvas, image URL, video, ndarray).",
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "ndarray": "^1.0.19",
+    "webgltexture-loader": "workspace:*",
+    "webgltexture-loader-dom": "workspace:*",
+    "webgltexture-loader-ndarray": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/ndarray": "^1.0.14",
+    "typescript": "^6",
+    "vite": "^7"
+  }
+}

--- a/apps/example-web/src/gl.ts
+++ b/apps/example-web/src/gl.ts
@@ -1,0 +1,88 @@
+/** Tiny WebGL helpers. Throws on any failure to keep the demo terse. */
+
+export function getGL(canvas: HTMLCanvasElement): WebGLRenderingContext {
+  const gl = canvas.getContext("webgl", { antialias: false, premultipliedAlpha: true });
+  if (!gl) throw new Error("WebGL is not supported in this browser");
+  return gl;
+}
+
+function compileShader(gl: WebGLRenderingContext, type: number, source: string): WebGLShader {
+  const shader = gl.createShader(type);
+  if (!shader) throw new Error("createShader failed");
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    const log = gl.getShaderInfoLog(shader) ?? "(no log)";
+    gl.deleteShader(shader);
+    throw new Error("shader compile failed: " + log);
+  }
+  return shader;
+}
+
+export function createProgram(gl: WebGLRenderingContext, vert: string, frag: string): WebGLProgram {
+  const program = gl.createProgram();
+  if (!program) throw new Error("createProgram failed");
+  const vs = compileShader(gl, gl.VERTEX_SHADER, vert);
+  const fs = compileShader(gl, gl.FRAGMENT_SHADER, frag);
+  gl.attachShader(program, vs);
+  gl.attachShader(program, fs);
+  gl.linkProgram(program);
+  gl.deleteShader(vs);
+  gl.deleteShader(fs);
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    const log = gl.getProgramInfoLog(program) ?? "(no log)";
+    gl.deleteProgram(program);
+    throw new Error("program link failed: " + log);
+  }
+  return program;
+}
+
+/** Allocate and bind a static fullscreen-quad VBO (two triangles). */
+export function createFullscreenQuad(gl: WebGLRenderingContext, attribLocation: number): void {
+  const buffer = gl.createBuffer();
+  if (!buffer) throw new Error("createBuffer failed");
+  gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+  gl.bufferData(
+    gl.ARRAY_BUFFER,
+    new Float32Array([-1, -1, 1, -1, -1, 1, -1, 1, 1, -1, 1, 1]),
+    gl.STATIC_DRAW,
+  );
+  gl.enableVertexAttribArray(attribLocation);
+  gl.vertexAttribPointer(attribLocation, 2, gl.FLOAT, false, 0, 0);
+}
+
+export const VERT_SRC = `
+attribute vec2 a_position;
+varying vec2 v_uv;
+void main() {
+  v_uv = a_position * 0.5 + 0.5;
+  gl_Position = vec4(a_position, 0.0, 1.0);
+}
+`;
+
+export const FRAG_SRC = `
+precision mediump float;
+varying vec2 v_uv;
+uniform sampler2D u_canvas;
+uniform sampler2D u_image;
+uniform sampler2D u_video;
+uniform sampler2D u_ndarray;
+void main() {
+  // 2x2 grid: (0,0) bottom-left, (1,1) top-right (WebGL UV origin = bottom-left).
+  vec2 cell = v_uv * 2.0;
+  vec2 local = fract(cell);
+  bool top = cell.y > 1.0;
+  bool right = cell.x > 1.0;
+  vec4 color;
+  if (top && !right) {
+    color = texture2D(u_canvas, local);
+  } else if (top && right) {
+    color = texture2D(u_image, local);
+  } else if (!top && !right) {
+    color = texture2D(u_video, local);
+  } else {
+    color = texture2D(u_ndarray, local);
+  }
+  gl_FragColor = color;
+}
+`;

--- a/apps/example-web/src/main.ts
+++ b/apps/example-web/src/main.ts
@@ -1,0 +1,307 @@
+// Side-effect imports register each loader on the global registry.
+import "webgltexture-loader-dom";
+import "webgltexture-loader-ndarray";
+
+import { LoaderResolver, type WebGLTextureLoader } from "webgltexture-loader";
+import type { NdArray } from "ndarray";
+
+import { createFullscreenQuad, createProgram, FRAG_SRC, getGL, VERT_SRC } from "./gl.js";
+import { makeCanvasSource, makeImageURL, makeNdArray, makeVideo } from "./sources.js";
+
+type Status = "loading" | "loaded" | "failed" | "disposed";
+
+type SourceInput = HTMLCanvasElement | HTMLVideoElement | string | NdArray<Uint8Array>;
+
+interface Source {
+  readonly name: string;
+  readonly position: string;
+  readonly uniform: string;
+  readonly input: SourceInput;
+  readonly textureUnit: number;
+  /** Whether this source mutates over time and needs `update()` every frame. */
+  readonly live: boolean;
+  /**
+   * Optional promise that rejects to signal the input cannot become ready
+   * (e.g. video errored or timed out). Raced against `loader.load()` so the
+   * demo doesn't hang in `loading` forever when the loader's poll-loop never
+   * resolves.
+   */
+  readonly failOn?: Promise<never>;
+  /**
+   * Optional callback invoked when `loader.load()` eventually resolves; lets
+   * the source clean up bookkeeping (e.g. cancel a readiness timeout) so a
+   * late-arriving `failOn` rejection can't flip the status back to `failed`.
+   */
+  readonly onReady?: () => void;
+  loader?: WebGLTextureLoader<SourceInput>;
+  /** True once we've configured tex params for the bound texture. */
+  paramsSet: boolean;
+  status: Status;
+  error?: string;
+}
+
+// CC0 sample on MDN's media bucket; advertises `Access-Control-Allow-Origin: *`,
+// required for `crossOrigin="anonymous"` so `gl.texImage2D(<video>)` doesn't
+// taint the canvas.
+const VIDEO_URL = "https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm";
+
+function need<T extends HTMLElement>(id: string): T {
+  const el = document.getElementById(id);
+  if (!el) throw new Error(`required DOM node #${id} not found`);
+  return el as T;
+}
+const canvasEl = need<HTMLCanvasElement>("gl");
+const sourcesEl = need<HTMLUListElement>("sources");
+const disposeBtn = need<HTMLButtonElement>("dispose");
+
+const gl = getGL(canvasEl);
+const resolver = new LoaderResolver(gl);
+
+const { video, failed: videoFailed, cancelTimeout: cancelVideoTimeout } = makeVideo(VIDEO_URL);
+
+const sources: Source[] = [
+  {
+    name: "HTMLCanvasElement",
+    position: "top-left",
+    uniform: "u_canvas",
+    input: makeCanvasSource(),
+    textureUnit: 0,
+    live: false,
+    paramsSet: false,
+    status: "loading",
+  },
+  {
+    name: "Image URL (data:)",
+    position: "top-right",
+    uniform: "u_image",
+    input: makeImageURL(),
+    textureUnit: 1,
+    live: false,
+    paramsSet: false,
+    status: "loading",
+  },
+  {
+    name: "HTMLVideoElement",
+    position: "bottom-left",
+    uniform: "u_video",
+    input: video,
+    textureUnit: 2,
+    live: true,
+    failOn: videoFailed,
+    onReady: cancelVideoTimeout,
+    paramsSet: false,
+    status: "loading",
+  },
+  {
+    name: "ndarray (RGBA Uint8)",
+    position: "bottom-right",
+    uniform: "u_ndarray",
+    input: makeNdArray(),
+    textureUnit: 3,
+    live: false,
+    paramsSet: false,
+    status: "loading",
+  },
+];
+
+const program = createProgram(gl, VERT_SRC, FRAG_SRC);
+gl.useProgram(program);
+createFullscreenQuad(gl, gl.getAttribLocation(program, "a_position"));
+for (const s of sources) {
+  const loc = gl.getUniformLocation(program, s.uniform);
+  if (loc) gl.uniform1i(loc, s.textureUnit);
+}
+
+// Resolve loaders once per source and kick off async loads.
+for (const s of sources) {
+  s.loader = resolver.resolve<SourceInput>(s.input);
+  if (!s.loader) {
+    s.status = "failed";
+    s.error = "no loader matched";
+    continue;
+  }
+  const load = s.loader.load(s.input);
+  load
+    .then(() => {
+      // `disposed` is terminal: don't flip status / clear error after the
+      // user pressed "Dispose all" or after `failOn` settled the source.
+      if (s.status === "disposed") return;
+      s.onReady?.();
+      // If a stale failOn rejection already flipped us to "failed", restore
+      // "loaded" once load actually resolves so the UI matches reality.
+      s.status = "loaded";
+      s.error = undefined;
+    })
+    .catch((e: unknown) => {
+      if (s.status === "disposed" || s.status === "failed") return;
+      s.status = "failed";
+      s.error = e instanceof Error ? e.message : String(e);
+    });
+  // Race against an optional input-level failure signal so a stuck source
+  // (e.g. video that never gets `videoWidth > 0`) surfaces as `failed`
+  // promptly. If `load` later resolves the .then above will re-flip us.
+  s.failOn?.catch((e: unknown) => {
+    if (s.status === "loaded" || s.status === "disposed") return;
+    s.status = "failed";
+    s.error = e instanceof Error ? e.message : String(e);
+  });
+}
+
+let disposed = false;
+
+function bindAndUpdate(s: Source): boolean {
+  if (!s.loader) return false;
+  // Activate the dedicated unit *before* anything that may bind a texture:
+  // sync loaders can perform their first upload inside `get()` and would
+  // bind onto whichever unit was active otherwise; same applies to
+  // `update()` for live sources.
+  gl.activeTexture(gl.TEXTURE0 + s.textureUnit);
+  const result = s.loader.get(s.input);
+  if (!result) return false;
+  gl.bindTexture(gl.TEXTURE_2D, result.texture);
+  // Only re-upload sources that actually mutate (video). Static sources are
+  // uploaded once by the loader's first `get()` call.
+  if (s.live) s.loader.update(s.input);
+  if (!s.paramsSet) {
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    s.paramsSet = true;
+  }
+  return true;
+}
+
+function render(): void {
+  resizeIfNeeded();
+  // Always sync the viewport so `gl.clear()` paths (loading / disposed) cover
+  // the full canvas after a resize, not just the previous frame's region.
+  gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
+  if (disposed) {
+    gl.clearColor(0, 0, 0, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    return;
+  }
+  let allReady = true;
+  for (const s of sources) {
+    if (!bindAndUpdate(s)) allReady = false;
+  }
+  if (allReady) {
+    gl.drawArrays(gl.TRIANGLES, 0, 6);
+  } else {
+    gl.clearColor(0.05, 0.06, 0.08, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+  }
+}
+
+function resizeIfNeeded(): void {
+  const dpr = window.devicePixelRatio || 1;
+  const cssW = canvasEl.clientWidth;
+  const cssH = canvasEl.clientHeight;
+  const w = Math.max(1, Math.round(cssW * dpr));
+  const h = Math.max(1, Math.round(cssH * dpr));
+  if (canvasEl.width !== w || canvasEl.height !== h) {
+    canvasEl.width = w;
+    canvasEl.height = h;
+  }
+}
+
+interface Row {
+  statusEl: HTMLSpanElement;
+  sizeEl: Text;
+  /** Last rendered values, used to skip no-op DOM writes. */
+  lastStatus: string;
+  lastSize: string;
+}
+
+function buildSidebar(): Row[] {
+  const rows: Row[] = [];
+  for (const s of sources) {
+    const li = document.createElement("li");
+    li.className = "source";
+
+    const header = document.createElement("header");
+    const name = document.createElement("span");
+    name.className = "name";
+    name.textContent = s.name;
+    const pos = document.createElement("span");
+    pos.className = "pos";
+    pos.textContent = s.position;
+    header.appendChild(name);
+    header.appendChild(pos);
+    li.appendChild(header);
+
+    const dl = document.createElement("dl");
+    const statusEl = document.createElement("span");
+    statusEl.className = "status loading";
+    statusEl.textContent = "loading";
+    appendRow(dl, "status", statusEl);
+
+    const sizeEl = document.createTextNode("—");
+    appendRow(dl, "size", sizeEl);
+
+    appendRow(dl, "loader", document.createTextNode(s.loader?.constructor.name ?? "—"));
+
+    li.appendChild(dl);
+    sourcesEl.appendChild(li);
+    rows.push({ statusEl, sizeEl, lastStatus: "", lastSize: "" });
+  }
+  return rows;
+}
+
+const rows = buildSidebar();
+
+function refreshSidebar(): void {
+  for (let i = 0; i < sources.length; i++) {
+    const s = sources[i]!;
+    const row = rows[i]!;
+    const statusText = s.error ? `failed: ${s.error}` : s.status;
+    if (statusText !== row.lastStatus) {
+      row.statusEl.className = "status " + s.status;
+      row.statusEl.textContent = statusText;
+      row.lastStatus = statusText;
+    }
+    const tex = disposed ? undefined : s.loader?.get(s.input);
+    const sizeText = tex ? `${tex.width}×${tex.height}` : "—";
+    if (sizeText !== row.lastSize) {
+      row.sizeEl.nodeValue = sizeText;
+      row.lastSize = sizeText;
+    }
+  }
+}
+
+function appendRow(dl: HTMLDListElement, label: string, value: Node): void {
+  const dt = document.createElement("dt");
+  dt.textContent = label;
+  const dd = document.createElement("dd");
+  dd.appendChild(value);
+  dl.appendChild(dt);
+  dl.appendChild(dd);
+}
+
+disposeBtn.addEventListener("click", () => {
+  if (disposed) return;
+  resolver.dispose();
+  // Cancel the video readiness timer / error listener and stop playback so
+  // disposal terminates *all* outstanding work, not just GPU resources.
+  cancelVideoTimeout();
+  video.pause();
+  video.removeAttribute("src");
+  video.load();
+  disposed = true;
+  for (const s of sources) {
+    s.status = "disposed";
+    // Clear any prior error so the sidebar doesn't render "failed: ..." on
+    // a disposed source (refreshSidebar surfaces `error` whenever it's set).
+    s.error = undefined;
+  }
+  disposeBtn.disabled = true;
+  disposeBtn.textContent = "Disposed";
+});
+
+function tick(): void {
+  render();
+  refreshSidebar();
+  requestAnimationFrame(tick);
+}
+tick();

--- a/apps/example-web/src/sources.ts
+++ b/apps/example-web/src/sources.ts
@@ -1,0 +1,150 @@
+import ndarray, { type NdArray } from "ndarray";
+
+/** Build a 256x256 canvas with a gradient, a circle, and a label. */
+export function makeCanvasSource(): HTMLCanvasElement {
+  const size = 256;
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("2D context unavailable");
+
+  const grad = ctx.createLinearGradient(0, 0, size, size);
+  grad.addColorStop(0, "#1f2c4a");
+  grad.addColorStop(1, "#7a3fa6");
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, 0, size, size);
+
+  ctx.beginPath();
+  ctx.arc(size / 2, size / 2, size / 3, 0, Math.PI * 2);
+  ctx.fillStyle = "#f0c419";
+  ctx.fill();
+
+  ctx.fillStyle = "#0e1014";
+  ctx.font = "bold 28px system-ui, sans-serif";
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.fillText("canvas", size / 2, size / 2);
+
+  return canvas;
+}
+
+/**
+ * Returns a `data:image/png` URL so the demo runs offline and exercises the
+ * image-URL loader path (which keys off `typeof input === "string"`).
+ */
+export function makeImageURL(): string {
+  const size = 64;
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("2D context unavailable");
+
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const r = (x * 255) / (size - 1);
+      const g = (y * 255) / (size - 1);
+      const b = 200 - ((x + y) * 100) / (2 * (size - 1));
+      ctx.fillStyle = `rgb(${r | 0},${g | 0},${b | 0})`;
+      ctx.fillRect(x, y, 1, 1);
+    }
+  }
+
+  ctx.fillStyle = "rgba(0,0,0,0.7)";
+  ctx.fillRect(2, size - 18, size - 4, 14);
+  ctx.fillStyle = "#fff";
+  ctx.font = "bold 10px system-ui, sans-serif";
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.fillText("image-url", size / 2, size - 11);
+
+  return canvas.toDataURL("image/png");
+}
+
+/**
+ * Make a <video> for the public-domain Big Buck Bunny snippet.
+ *
+ * Returns the element along with a `failed` promise that rejects on a media
+ * error or after `timeoutMs` of no readiness, plus a `cancelTimeout` that
+ * the caller should invoke once the video is actually ready (e.g. after
+ * `loader.load()` resolves). `VideoTextureLoader.load()` polls `videoWidth >
+ * 0` and never rejects on its own — the demo watches `failed` so the UI can
+ * surface CORS / network / autoplay problems instead of hanging in
+ * `loading` forever, and clears the timeout on success so a delayed
+ * resolution doesn't spuriously flip the UI to `failed`.
+ */
+export function makeVideo(
+  src: string,
+  timeoutMs = 10000,
+): {
+  video: HTMLVideoElement;
+  failed: Promise<never>;
+  cancelTimeout: () => void;
+} {
+  const video = document.createElement("video");
+  // crossOrigin must be set *before* src so the request is issued in CORS
+  // mode; otherwise the response can taint the media and break WebGL
+  // texture uploads in some browsers.
+  video.crossOrigin = "anonymous";
+  video.muted = true;
+  video.autoplay = true;
+  video.loop = true;
+  video.playsInline = true;
+  video.src = src;
+  // start playback as soon as we can; ignore the rejected promise (autoplay
+  // policy may delay until first user gesture, which is fine — the loader
+  // just waits for videoWidth > 0).
+  video.play().catch(() => {});
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let onError: (() => void) | undefined;
+  const cleanup = () => {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+    if (onError) {
+      video.removeEventListener("error", onError);
+      onError = undefined;
+    }
+  };
+  const failed = new Promise<never>((_, reject) => {
+    onError = () => {
+      const err = video.error;
+      cleanup();
+      reject(new Error(err ? `video error (code ${err.code}): ${err.message}` : "video error"));
+    };
+    video.addEventListener("error", onError);
+    timer = setTimeout(() => {
+      cleanup();
+      if (video.videoWidth === 0) {
+        reject(new Error(`video not ready after ${timeoutMs}ms (CORS/network/autoplay?)`));
+      }
+    }, timeoutMs);
+  });
+  // suppress the default unhandled-rejection if nothing races against it
+  failed.catch(() => {});
+  return { video, failed, cancelTimeout: cleanup };
+}
+
+/** Build a 64x64 RGBA Uint8Array with a plasma-ish pattern. */
+export function makeNdArray(): NdArray<Uint8Array> {
+  const size = 64;
+  const data = new Uint8Array(size * size * 4);
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const u = x / size;
+      const v = y / size;
+      const r = Math.sin(u * 8) * 0.5 + 0.5;
+      const g = Math.sin(v * 8 + 1.0) * 0.5 + 0.5;
+      const b = Math.sin((u + v) * 6 + 2.0) * 0.5 + 0.5;
+      const i = (y * size + x) * 4;
+      data[i] = (r * 255) | 0;
+      data[i + 1] = (g * 255) | 0;
+      data[i + 2] = (b * 255) | 0;
+      data[i + 3] = 255;
+    }
+  }
+  return ndarray(data, [size, size, 4]);
+}

--- a/apps/example-web/tsconfig.json
+++ b/apps/example-web/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2023", "DOM"],
+    "noEmit": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": false,
+    "types": []
+  },
+  "include": ["src/**/*", "vite.config.ts"]
+}

--- a/apps/example-web/vite.config.ts
+++ b/apps/example-web/vite.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig } from "vite";
+
+// typedarray-pool (transitive of webgltexture-loader-ndarray) references `global`
+// at module top-level. Map it to `globalThis` so the bundle works in browsers.
+// Required in BOTH the main `define` (used by `vite build` and user code in dev)
+// AND inside `optimizeDeps.esbuildOptions.define`, because Vite's dep pre-bundling
+// step runs esbuild standalone and doesn't inherit the main define — without it
+// `global.__TYPEDARRAY_POOL` survives unrewritten in the pre-bundled chunk and
+// crashes the page on first import.
+const GLOBAL_DEFINE = { global: "globalThis" } as const;
+
+export default defineConfig({
+  define: GLOBAL_DEFINE,
+  optimizeDeps: {
+    esbuildOptions: {
+      define: GLOBAL_DEFINE,
+    },
+    // The workspace packages publish CommonJS (`tsc` default with NodeNext +
+    // CJS-shaped runtime). Force-include them in Vite's pre-bundling so they
+    // get the CJS-to-ESM interop, otherwise Rollup can't trace named exports
+    // and `vite build` errors out with "X is not exported".
+    include: [
+      "webgltexture-loader",
+      "webgltexture-loader-dom",
+      "webgltexture-loader-dom-canvas",
+      "webgltexture-loader-dom-image-url",
+      "webgltexture-loader-dom-video",
+      "webgltexture-loader-ndarray",
+      "ndarray",
+    ],
+  },
+  build: {
+    commonjsOptions: {
+      include: [/webgltexture-loader/, /ndarray/],
+    },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -7,15 +7,16 @@
   "author": "Gaëtan Renaudeau <renaudeau.gaetan@gmail.com>",
   "repository": "https://github.com/gre/webgltexture-loader",
   "workspaces": [
-    "packages/*"
+    "packages/*",
+    "apps/*"
   ],
   "scripts": {
     "test": "jest",
-    "build": "yarn workspaces foreach -Apt run build",
+    "build": "yarn workspaces foreach -Apt --no-private run build",
     "lint": "oxlint",
-    "format": "oxfmt --check \"packages/**/*.{ts,tsx}\" \"jest.config.js\"",
-    "format:fix": "oxfmt \"packages/**/*.{ts,tsx}\" \"jest.config.js\"",
-    "typecheck": "yarn workspaces foreach -A run typecheck",
+    "format": "oxfmt --check \"packages/**/*.{ts,tsx}\" \"apps/**/*.{ts,tsx}\" \"jest.config.js\"",
+    "format:fix": "oxfmt \"packages/**/*.{ts,tsx}\" \"apps/**/*.{ts,tsx}\" \"jest.config.js\"",
+    "typecheck": "yarn workspaces foreach -A --no-private run typecheck",
     "changeset:version": "changeset version",
     "release": "yarn build && changeset publish"
   },

--- a/packages/webgltexture-loader-ndarray/src/NDArrayTextureLoader.ts
+++ b/packages/webgltexture-loader-ndarray/src/NDArrayTextureLoader.ts
@@ -1,3 +1,8 @@
+// Imported first so the `global`/`Buffer` polyfills run before any transitive
+// import of `typedarray-pool` (which references `global` at module top-level).
+// Anchored here — the package's published entry point — so the shim is always
+// loaded by any consumer of this loader.
+import "./globalShim.js";
 import type { NdArray } from "ndarray";
 import {
   createTexture,

--- a/packages/webgltexture-loader-ndarray/src/drawNDArrayTexture.ts
+++ b/packages/webgltexture-loader-ndarray/src/drawNDArrayTexture.ts
@@ -1,3 +1,6 @@
+// `globalShim.js` is imported by `NDArrayTextureLoader.ts` (this package's
+// entry point) before any path reaches typedarray-pool, so we don't repeat
+// the side-effect import here.
 import type { NdArray } from "ndarray";
 import ndarray from "ndarray";
 import ops from "ndarray-ops";
@@ -5,12 +8,6 @@ import pool from "typedarray-pool";
 
 // Some of the texImage2D logic below is adapted from
 // https://github.com/stackgl/gl-texture2d/blob/master/texture.js
-
-type GlobalWithBuffer = { Buffer?: { isBuffer: (b: unknown) => boolean } };
-// Browser shim so typedarray-pool's Buffer.isBuffer check doesn't crash.
-if (typeof (globalThis as GlobalWithBuffer).Buffer === "undefined") {
-  (globalThis as GlobalWithBuffer).Buffer = { isBuffer: () => false };
-}
 
 function isPacked(shape: number[], stride: number[]): boolean {
   if (shape.length === 3) {

--- a/packages/webgltexture-loader-ndarray/src/globalShim.ts
+++ b/packages/webgltexture-loader-ndarray/src/globalShim.ts
@@ -1,0 +1,26 @@
+// typedarray-pool references `global` at module top-level (e.g. `global.__TYPEDARRAY_POOL`).
+// In browsers there is no `global` — only `globalThis` / `window`. The recommended
+// fix is for the consumer's bundler to map `global` to `globalThis` (Vite, Webpack,
+// esbuild all support this via `define`). This file is the runtime fallback for
+// consumers who don't configure that, and also shims `Buffer.isBuffer` which
+// typedarray-pool calls at runtime.
+//
+// Use Object.defineProperty so the assignment isn't DCE'd by esbuild's tree-shaker
+// (which can otherwise consider `globalThis.global = globalThis` a dead store).
+const root = globalThis as unknown as Record<string, unknown>;
+
+if (typeof root.global === "undefined") {
+  Object.defineProperty(root, "global", {
+    value: root,
+    writable: true,
+    configurable: true,
+  });
+}
+
+if (typeof root.Buffer === "undefined") {
+  Object.defineProperty(root, "Buffer", {
+    value: { isBuffer: () => false },
+    writable: true,
+    configurable: true,
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -702,6 +702,188 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/aix-ppc64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/aix-ppc64@npm:0.27.7"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/android-arm64@npm:0.27.7"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/android-arm@npm:0.27.7"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/android-x64@npm:0.27.7"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/darwin-arm64@npm:0.27.7"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/darwin-x64@npm:0.27.7"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/freebsd-arm64@npm:0.27.7"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/freebsd-x64@npm:0.27.7"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-arm64@npm:0.27.7"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-arm@npm:0.27.7"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ia32@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-ia32@npm:0.27.7"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-loong64@npm:0.27.7"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-mips64el@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-mips64el@npm:0.27.7"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-ppc64@npm:0.27.7"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-riscv64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-riscv64@npm:0.27.7"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-s390x@npm:0.27.7"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-x64@npm:0.27.7"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/netbsd-arm64@npm:0.27.7"
+  conditions: os=netbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/netbsd-x64@npm:0.27.7"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/openbsd-arm64@npm:0.27.7"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/openbsd-x64@npm:0.27.7"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openharmony-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/openharmony-arm64@npm:0.27.7"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/sunos-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/sunos-x64@npm:0.27.7"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/win32-arm64@npm:0.27.7"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-ia32@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/win32-ia32@npm:0.27.7"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/win32-x64@npm:0.27.7"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@inquirer/external-editor@npm:^1.0.2":
   version: 1.0.3
   resolution: "@inquirer/external-editor@npm:1.0.3"
@@ -1419,6 +1601,181 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-android-arm-eabi@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-android-arm-eabi@npm:4.60.2"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-android-arm64@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-android-arm64@npm:4.60.2"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-darwin-arm64@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-darwin-arm64@npm:4.60.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-darwin-x64@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-darwin-x64@npm:4.60.2"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-freebsd-arm64@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-freebsd-arm64@npm:4.60.2"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-freebsd-x64@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-freebsd-x64@npm:4.60.2"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm-gnueabihf@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.60.2"
+  conditions: os=linux & cpu=arm & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm-musleabihf@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.60.2"
+  conditions: os=linux & cpu=arm & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm64-gnu@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.60.2"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm64-musl@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.60.2"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-loong64-gnu@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-loong64-gnu@npm:4.60.2"
+  conditions: os=linux & cpu=loong64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-loong64-musl@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-loong64-musl@npm:4.60.2"
+  conditions: os=linux & cpu=loong64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-ppc64-gnu@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-ppc64-gnu@npm:4.60.2"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-ppc64-musl@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-ppc64-musl@npm:4.60.2"
+  conditions: os=linux & cpu=ppc64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-riscv64-gnu@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.60.2"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-riscv64-musl@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.60.2"
+  conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-s390x-gnu@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.60.2"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-x64-gnu@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.60.2"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-x64-musl@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-x64-musl@npm:4.60.2"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-openbsd-x64@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-openbsd-x64@npm:4.60.2"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-openharmony-arm64@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-openharmony-arm64@npm:4.60.2"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-arm64-msvc@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.60.2"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-ia32-msvc@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.60.2"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-x64-gnu@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-win32-x64-gnu@npm:4.60.2"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-x64-msvc@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.60.2"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@sinclair/typebox@npm:^0.34.0":
   version: 0.34.49
   resolution: "@sinclair/typebox@npm:0.34.49"
@@ -1491,6 +1848,13 @@ __metadata:
   dependencies:
     "@babel/types": "npm:^7.3.0"
   checksum: 10c0/2ec77e5307473c1accc1cb7fe65332fe4c873374cde16ffdc631951372be9fdffbb9fe9d7251efdff52ae4f73634f4bff80d808cb90513abbeb61945c02e1866
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:1.0.8":
+  version: 1.0.8
+  resolution: "@types/estree@npm:1.0.8"
+  checksum: 10c0/39d34d1afaa338ab9763f37ad6066e3f349444f9052b9676a7cc0252ef9485a41c6d81c9c4e0d26e9077993354edf25efc853f3224dd4b447175ef62bdcc86a5
   languageName: node
   linkType: hard
 
@@ -2412,6 +2776,95 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild@npm:^0.27.0":
+  version: 0.27.7
+  resolution: "esbuild@npm:0.27.7"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.27.7"
+    "@esbuild/android-arm": "npm:0.27.7"
+    "@esbuild/android-arm64": "npm:0.27.7"
+    "@esbuild/android-x64": "npm:0.27.7"
+    "@esbuild/darwin-arm64": "npm:0.27.7"
+    "@esbuild/darwin-x64": "npm:0.27.7"
+    "@esbuild/freebsd-arm64": "npm:0.27.7"
+    "@esbuild/freebsd-x64": "npm:0.27.7"
+    "@esbuild/linux-arm": "npm:0.27.7"
+    "@esbuild/linux-arm64": "npm:0.27.7"
+    "@esbuild/linux-ia32": "npm:0.27.7"
+    "@esbuild/linux-loong64": "npm:0.27.7"
+    "@esbuild/linux-mips64el": "npm:0.27.7"
+    "@esbuild/linux-ppc64": "npm:0.27.7"
+    "@esbuild/linux-riscv64": "npm:0.27.7"
+    "@esbuild/linux-s390x": "npm:0.27.7"
+    "@esbuild/linux-x64": "npm:0.27.7"
+    "@esbuild/netbsd-arm64": "npm:0.27.7"
+    "@esbuild/netbsd-x64": "npm:0.27.7"
+    "@esbuild/openbsd-arm64": "npm:0.27.7"
+    "@esbuild/openbsd-x64": "npm:0.27.7"
+    "@esbuild/openharmony-arm64": "npm:0.27.7"
+    "@esbuild/sunos-x64": "npm:0.27.7"
+    "@esbuild/win32-arm64": "npm:0.27.7"
+    "@esbuild/win32-ia32": "npm:0.27.7"
+    "@esbuild/win32-x64": "npm:0.27.7"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-arm64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/openharmony-arm64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 10c0/ccd51f0555708bc9ff4ec9dc3ac92d3daacd45ecaac949ca8645984c5c323bf8cefe98c2df307418685e0b4ce37f9a3bdbfe8e3651fe632a0059a436195a17d4
+  languageName: node
+  linkType: hard
+
 "escalade@npm:^3.1.1":
   version: 3.1.1
   resolution: "escalade@npm:3.1.1"
@@ -2449,6 +2902,20 @@ __metadata:
   checksum: 10c0/ad4bab9ead0808cf56501750fd9d3fb276f6b105f987707d059005d57e182d18a7c9ec7f3a01794ebddcca676773e42ca48a32d67a250c9d35e009ca613caba3
   languageName: node
   linkType: hard
+
+"example-web@workspace:apps/example-web":
+  version: 0.0.0-use.local
+  resolution: "example-web@workspace:apps/example-web"
+  dependencies:
+    "@types/ndarray": "npm:^1.0.14"
+    ndarray: "npm:^1.0.19"
+    typescript: "npm:^6"
+    vite: "npm:^7"
+    webgltexture-loader: "workspace:*"
+    webgltexture-loader-dom: "workspace:*"
+    webgltexture-loader-ndarray: "workspace:*"
+  languageName: unknown
+  linkType: soft
 
 "execa@npm:^5.1.1":
   version: 5.1.1
@@ -2631,7 +3098,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:^2.3.3":
+"fsevents@npm:^2.3.3, fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
@@ -2641,7 +3108,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@npm%3A^2.3.3#optional!builtin<compat/fsevents>":
+"fsevents@patch:fsevents@npm%3A^2.3.3#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.3#optional!builtin<compat/fsevents>":
   version: 2.3.3
   resolution: "fsevents@patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
   dependencies:
@@ -3770,6 +4237,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nanoid@npm:^3.3.11":
+  version: 3.3.11
+  resolution: "nanoid@npm:3.3.11"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 10c0/40e7f70b3d15f725ca072dfc4f74e81fcf1fbb02e491cf58ac0c79093adc9b0a73b152bcde57df4b79cd097e13023d7504acb38404a4da7bc1cd8e887b82fe0b
+  languageName: node
+  linkType: hard
+
 "napi-build-utils@npm:^2.0.0":
   version: 2.0.0
   resolution: "napi-build-utils@npm:2.0.0"
@@ -4216,6 +4692,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss@npm:^8.5.6":
+  version: 8.5.12
+  resolution: "postcss@npm:8.5.12"
+  dependencies:
+    nanoid: "npm:^3.3.11"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10c0/5baebaf574c567bc1b3d61197f38af4ce5920b8f611c887fb6bc3dcc14af00253c169dbf19897bc889cce0b0d9818ab5eb4ea0caedf02b0bab10da8a43ce8c12
+  languageName: node
+  linkType: hard
+
 "prebuild-install@npm:^7.1.3":
   version: 7.1.3
   resolution: "prebuild-install@npm:7.1.3"
@@ -4382,6 +4869,96 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rollup@npm:^4.43.0":
+  version: 4.60.2
+  resolution: "rollup@npm:4.60.2"
+  dependencies:
+    "@rollup/rollup-android-arm-eabi": "npm:4.60.2"
+    "@rollup/rollup-android-arm64": "npm:4.60.2"
+    "@rollup/rollup-darwin-arm64": "npm:4.60.2"
+    "@rollup/rollup-darwin-x64": "npm:4.60.2"
+    "@rollup/rollup-freebsd-arm64": "npm:4.60.2"
+    "@rollup/rollup-freebsd-x64": "npm:4.60.2"
+    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.60.2"
+    "@rollup/rollup-linux-arm-musleabihf": "npm:4.60.2"
+    "@rollup/rollup-linux-arm64-gnu": "npm:4.60.2"
+    "@rollup/rollup-linux-arm64-musl": "npm:4.60.2"
+    "@rollup/rollup-linux-loong64-gnu": "npm:4.60.2"
+    "@rollup/rollup-linux-loong64-musl": "npm:4.60.2"
+    "@rollup/rollup-linux-ppc64-gnu": "npm:4.60.2"
+    "@rollup/rollup-linux-ppc64-musl": "npm:4.60.2"
+    "@rollup/rollup-linux-riscv64-gnu": "npm:4.60.2"
+    "@rollup/rollup-linux-riscv64-musl": "npm:4.60.2"
+    "@rollup/rollup-linux-s390x-gnu": "npm:4.60.2"
+    "@rollup/rollup-linux-x64-gnu": "npm:4.60.2"
+    "@rollup/rollup-linux-x64-musl": "npm:4.60.2"
+    "@rollup/rollup-openbsd-x64": "npm:4.60.2"
+    "@rollup/rollup-openharmony-arm64": "npm:4.60.2"
+    "@rollup/rollup-win32-arm64-msvc": "npm:4.60.2"
+    "@rollup/rollup-win32-ia32-msvc": "npm:4.60.2"
+    "@rollup/rollup-win32-x64-gnu": "npm:4.60.2"
+    "@rollup/rollup-win32-x64-msvc": "npm:4.60.2"
+    "@types/estree": "npm:1.0.8"
+    fsevents: "npm:~2.3.2"
+  dependenciesMeta:
+    "@rollup/rollup-android-arm-eabi":
+      optional: true
+    "@rollup/rollup-android-arm64":
+      optional: true
+    "@rollup/rollup-darwin-arm64":
+      optional: true
+    "@rollup/rollup-darwin-x64":
+      optional: true
+    "@rollup/rollup-freebsd-arm64":
+      optional: true
+    "@rollup/rollup-freebsd-x64":
+      optional: true
+    "@rollup/rollup-linux-arm-gnueabihf":
+      optional: true
+    "@rollup/rollup-linux-arm-musleabihf":
+      optional: true
+    "@rollup/rollup-linux-arm64-gnu":
+      optional: true
+    "@rollup/rollup-linux-arm64-musl":
+      optional: true
+    "@rollup/rollup-linux-loong64-gnu":
+      optional: true
+    "@rollup/rollup-linux-loong64-musl":
+      optional: true
+    "@rollup/rollup-linux-ppc64-gnu":
+      optional: true
+    "@rollup/rollup-linux-ppc64-musl":
+      optional: true
+    "@rollup/rollup-linux-riscv64-gnu":
+      optional: true
+    "@rollup/rollup-linux-riscv64-musl":
+      optional: true
+    "@rollup/rollup-linux-s390x-gnu":
+      optional: true
+    "@rollup/rollup-linux-x64-gnu":
+      optional: true
+    "@rollup/rollup-linux-x64-musl":
+      optional: true
+    "@rollup/rollup-openbsd-x64":
+      optional: true
+    "@rollup/rollup-openharmony-arm64":
+      optional: true
+    "@rollup/rollup-win32-arm64-msvc":
+      optional: true
+    "@rollup/rollup-win32-ia32-msvc":
+      optional: true
+    "@rollup/rollup-win32-x64-gnu":
+      optional: true
+    "@rollup/rollup-win32-x64-msvc":
+      optional: true
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: 10c0/f67d6156fc5b895f33b929a4762392906d00fa5550f0a1f5e66519ab1c05d835aec5f201b4e748c29d1c87f024d3d9c4b0a2d1285668456db661d82b961d379c
+  languageName: node
+  linkType: hard
+
 "run-parallel@npm:^1.1.9":
   version: 1.2.0
   resolution: "run-parallel@npm:1.2.0"
@@ -4495,6 +5072,13 @@ __metadata:
   version: 3.0.0
   resolution: "slash@npm:3.0.0"
   checksum: 10c0/e18488c6a42bdfd4ac5be85b2ced3ccd0224773baae6ad42cfbb9ec74fc07f9fa8396bd35ee638084ead7a2a0818eb5e7151111544d4731ce843019dab4be47b
+  languageName: node
+  linkType: hard
+
+"source-map-js@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "source-map-js@npm:1.2.1"
+  checksum: 10c0/7bda1fc4c197e3c6ff17de1b8b2c20e60af81b63a52cb32ec5a5d67a20a7d42651e2cb34ebe93833c5a2a084377e17455854fee3e21e7925c64a51b6a52b0faf
   languageName: node
   linkType: hard
 
@@ -4744,7 +5328,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyglobby@npm:^0.2.12":
+"tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.15":
   version: 0.2.16
   resolution: "tinyglobby@npm:0.2.16"
   dependencies:
@@ -5027,6 +5611,61 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vite@npm:^7":
+  version: 7.3.2
+  resolution: "vite@npm:7.3.2"
+  dependencies:
+    esbuild: "npm:^0.27.0"
+    fdir: "npm:^6.5.0"
+    fsevents: "npm:~2.3.3"
+    picomatch: "npm:^4.0.3"
+    postcss: "npm:^8.5.6"
+    rollup: "npm:^4.43.0"
+    tinyglobby: "npm:^0.2.15"
+  peerDependencies:
+    "@types/node": ^20.19.0 || >=22.12.0
+    jiti: ">=1.21.0"
+    less: ^4.0.0
+    lightningcss: ^1.21.0
+    sass: ^1.70.0
+    sass-embedded: ^1.70.0
+    stylus: ">=0.54.8"
+    sugarss: ^5.0.0
+    terser: ^5.16.0
+    tsx: ^4.8.1
+    yaml: ^2.4.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    jiti:
+      optional: true
+    less:
+      optional: true
+    lightningcss:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+    tsx:
+      optional: true
+    yaml:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 10c0/74be36907e208916f18bfec81c8eba18b869f0a170f1ece0a4dcb14874d0f0e7c022fb6c2ad896e3ee6c973fe88f53ac23b4078879ada340d8b263260868b8d4
+  languageName: node
+  linkType: hard
+
 "walker@npm:^1.0.8":
   version: 1.0.8
   resolution: "walker@npm:1.0.8"
@@ -5060,7 +5699,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"webgltexture-loader-dom@workspace:packages/webgltexture-loader-dom":
+"webgltexture-loader-dom@workspace:*, webgltexture-loader-dom@workspace:packages/webgltexture-loader-dom":
   version: 0.0.0-use.local
   resolution: "webgltexture-loader-dom@workspace:packages/webgltexture-loader-dom"
   dependencies:
@@ -5114,7 +5753,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"webgltexture-loader-ndarray@workspace:packages/webgltexture-loader-ndarray":
+"webgltexture-loader-ndarray@workspace:*, webgltexture-loader-ndarray@workspace:packages/webgltexture-loader-ndarray":
   version: 0.0.0-use.local
   resolution: "webgltexture-loader-ndarray@workspace:packages/webgltexture-loader-ndarray"
   dependencies:
@@ -5150,7 +5789,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"webgltexture-loader@npm:^2.0.0, webgltexture-loader@workspace:packages/webgltexture-loader":
+"webgltexture-loader@npm:^2.0.0, webgltexture-loader@workspace:*, webgltexture-loader@workspace:packages/webgltexture-loader":
   version: 0.0.0-use.local
   resolution: "webgltexture-loader@workspace:packages/webgltexture-loader"
   languageName: unknown


### PR DESCRIPTION
## Summary

Adds `apps/example-web/` (Vite 7 + vanilla TypeScript) — a visual smoke test that exercises every web-side `webgltexture-loader` end-to-end so contributors can quickly confirm the lib works.

A single fragment shader samples four textures and tiles them in a 2x2 grid:

| Quadrant     | Loader                  | Source                                           |
| ------------ | ----------------------- | ------------------------------------------------ |
| top-left     | `CanvasTextureLoader`   | Programmatic `HTMLCanvasElement` (gradient + circle + label). |
| top-right    | `ImageURLTextureLoader` | `data:image/png` URL generated at runtime (offline-friendly). |
| bottom-left  | `VideoTextureLoader`    | CC0 WebM streamed from MDN's media bucket (`Access-Control-Allow-Origin: *`, required for `crossOrigin="anonymous"`). |
| bottom-right | `NDArrayTextureLoader`  | 64x64 RGBA `Uint8Array` plasma pattern.          |

A sidebar lists each input, its resolved size, the loader class that handled it, and a status pill. A "Dispose all" button calls `resolver.dispose()` to demonstrate cleanup.

## Wiring

```ts
import "webgltexture-loader-dom";       // registers Canvas/ImageURL/Video
import "webgltexture-loader-ndarray";   // registers NDArray
import { LoaderResolver } from "webgltexture-loader";
const resolver = new LoaderResolver(gl);
const loader = resolver.resolve(input);
await loader?.load(input);
loader?.update(input); // every frame for live sources
```

## Build cascade

- `apps/*` is added to the root `workspaces`.
- Root `yarn build` / `yarn typecheck` use `--no-private` so they only cascade into the library packages — the demo isn't published, so library builds stay fast.
- `yarn lint`, `yarn format`, and `yarn test` cover the app source (formatter glob widened to `apps/**/*.{ts,tsx}`).
- The app's own build is verified with `yarn workspace example-web build` (`tsc --noEmit && vite build`); CI will catch app regressions even though the app is outside the library cascade.

## Out of scope

The Expo and React Native loaders are intentionally not exercised here — they require a native runtime that can't run in a plain web demo.

## Test plan

- [ ] `corepack yarn install` (lockfile updated; vite, typescript, ndarray, esbuild dependencies pulled in).
- [ ] `corepack yarn build` — only library packages build.
- [ ] `corepack yarn test` — 29 tests still pass.
- [ ] `corepack yarn lint` — 0 warnings, 0 errors.
- [ ] `corepack yarn format` — clean.
- [ ] `corepack yarn workspace example-web build` — type-checks and bundles.
- [ ] `corepack yarn workspace example-web dev` — open the URL, confirm all four quadrants render and the sidebar shows `loaded` for each, then click "Dispose all".

🤖 Generated with [Claude Code](https://claude.com/claude-code)