### PR TITLE
fix(expo-camera): detect modern CameraView instances on Expo SDK 54+

### DIFF
--- a/.changeset/fix-cameraview-ref.md
+++ b/.changeset/fix-cameraview-ref.md
@@ -1,0 +1,19 @@
+---
+"webgltexture-loader-expo-camera": patch
+"webgltexture-loader-expo": patch
+---
+
+expo-camera: detect modern `CameraView` instances on Expo SDK 54+. The class
+exposes none of the legacy duck-typed markers (`_nativeTag` /
+`__internalInstanceHandle` / `getNativeRef`) and the legacy `instanceof
+Camera` fallback is dead because `Camera` is no longer exported. Adds a
+fifth `instanceof CameraView` branch in `canLoad`, and unwraps the wrapper
+to `instance._cameraRef.current` before calling Expo's GL bridge AND inside
+`inputHash` (so the WeakMap-based hash counter keys on the same native
+identity that's passed to the native call — otherwise dispose/cache
+invariants get desynced).
+
+expo: reword the "ExponentGLObjectManager.createObjectAsync is not
+available" message and demote it to `console.debug`. The previous wording
+falsely implied the user was on the wrong Expo version; the loader is just
+a legacy fallback that doesn't apply on SDK 51+.

--- a/packages/webgltexture-loader-expo-camera/src/ExpoCameraTextureLoader.test.ts
+++ b/packages/webgltexture-loader-expo-camera/src/ExpoCameraTextureLoader.test.ts
@@ -4,6 +4,13 @@ jest.mock(
   "expo-camera",
   () => ({
     Camera: class Camera {},
+    // Modern (SDK 51+) class component. Real instances on SDK 54 carry a
+    // private `_cameraRef = createRef()` whose `.current` is the actual
+    // native handle; the loader unwraps to that before calling Expo's GL
+    // bridge.
+    CameraView: class CameraView {
+      _cameraRef: { current: unknown } = { current: null };
+    },
   }),
   { virtual: true },
 );
@@ -59,16 +66,31 @@ test("canLoad accepts a duck-typed object with __internalInstanceHandle", () => 
   expect(loader.canLoad({ __internalInstanceHandle: {} })).toBe(true);
 });
 
-// Pull the mocked `Camera` class the loader sees, via `jest.requireMock`
-// so we hit the same module identity. Instances do not have `_nativeTag` /
-// `__internalInstanceHandle` / `getNativeRef`, so this exercises the
-// `instanceof` back-compat path.
-const MockedCamera = jest.requireMock<{ Camera: new () => unknown }>("expo-camera").Camera;
+// Pull the mocked `Camera` / `CameraView` classes the loader sees, via
+// `jest.requireMock` so we hit the same module identity. Instances do not
+// have `_nativeTag` / `__internalInstanceHandle` / `getNativeRef`, so they
+// exercise the `instanceof` back-compat / modern paths.
+const ExpoCameraMock = jest.requireMock<{
+  Camera: new () => unknown;
+  CameraView: new () => { _cameraRef: { current: unknown } };
+}>("expo-camera");
+const MockedCamera = ExpoCameraMock.Camera;
+const MockedCameraView = ExpoCameraMock.CameraView;
 
 test("canLoad accepts a legacy Camera class instance (SDK <= 50)", () => {
   const legacyInstance = new MockedCamera();
   const loader = new ExpoCameraTextureLoader(mockGL());
   expect(loader.canLoad(legacyInstance)).toBe(true);
+});
+
+test("canLoad accepts a modern CameraView class instance (SDK 51+)", () => {
+  // Real SDK 54 instance shape: no `_nativeTag` / `__internalInstanceHandle`
+  // / `getNativeRef`; only the private `_cameraRef`. None of the duck-typed
+  // branches match — only the `instanceof CameraView` branch saves us.
+  const cameraView = new MockedCameraView();
+  cameraView._cameraRef = { current: { _nativeTag: 224 } };
+  const loader = new ExpoCameraTextureLoader(mockGL());
+  expect(loader.canLoad(cameraView)).toBe(true);
 });
 
 test("canLoad accepts the { camera, width, height } wrapper shape", () => {
@@ -92,6 +114,29 @@ test("inputHash returns different values for different refs", () => {
   const a = { _nativeTag: 1 };
   const b = { _nativeTag: 2 };
   expect(loader.inputHash(a)).not.toBe(loader.inputHash(b));
+});
+
+test("inputHash is idempotent across the CameraView wrapper", () => {
+  // Two calls with the same CameraView wrapper must produce the same hash —
+  // the unwrap step keys on `_cameraRef.current`, not the wrapper identity.
+  const loader = new ExpoCameraTextureLoader(mockGL());
+  const cameraView = new MockedCameraView();
+  cameraView._cameraRef = { current: { _nativeTag: 224 } };
+  const h1 = loader.inputHash(cameraView);
+  const h2 = loader.inputHash(cameraView);
+  expect(h1).toBe(h2);
+});
+
+test("inputHash treats CameraView and its inner native ref as equivalent", () => {
+  // The whole point of unwrapping inside `inputHash`: the WeakMap-based
+  // hash counter MUST key on the native ref, otherwise dispose / cache
+  // invariants get desynced when callers pass the wrapper in one place
+  // and the unwrapped ref in another.
+  const loader = new ExpoCameraTextureLoader(mockGL());
+  const nativeRef = { _nativeTag: 224 };
+  const cameraView = new MockedCameraView();
+  cameraView._cameraRef = { current: nativeRef };
+  expect(loader.inputHash(cameraView)).toBe(loader.inputHash(nativeRef));
 });
 
 test("load returns the explicit width/height when given the wrapper shape", async () => {

--- a/packages/webgltexture-loader-expo-camera/src/ExpoCameraTextureLoader.ts
+++ b/packages/webgltexture-loader-expo-camera/src/ExpoCameraTextureLoader.ts
@@ -7,6 +7,7 @@ import { NativeModulesProxy } from "expo-modules-core";
 import { globalRegistry, WebGLTextureLoaderAsyncHashCache } from "webgltexture-loader";
 
 const LegacyCamera: unknown = (ExpoCameraModule as { Camera?: unknown }).Camera;
+const CameraView: unknown = (ExpoCameraModule as { CameraView?: unknown }).CameraView;
 
 const neverEnding: Promise<never> = new Promise(() => {});
 
@@ -18,16 +19,21 @@ const neverEnding: Promise<never> = new Promise(() => {});
  * - `_nativeTag` — RN class component / ref-forwarded class (legacy `Camera`).
  * - `__internalInstanceHandle` — RN New Architecture (Fabric) ref.
  * - `getNativeRef()` — `CameraView`'s pattern in some SDKs.
+ * - `instanceof CameraView` — modern (SDK 51+) class component instance.
+ *   Its real native ref is at `instance._cameraRef.current`; we unwrap to
+ *   that before calling Expo's GL bridge (see `unwrapNativeCameraRef`).
  *
  * As a back-compat fallback we also accept anything that is `instanceof`
- * the legacy `Camera` class. The class is read off the namespace import
- * (rather than a named import) and gated behind `typeof === "function"`,
- * so SDKs that drop the export entirely don't crash at module load.
+ * the legacy `Camera` class. Both class references are read off the
+ * namespace import (rather than a named import) and gated behind
+ * `typeof === "function"`, so SDKs that drop the export entirely don't
+ * crash at module load.
  */
 type LegacyCameraOrCameraViewRef = {
   _nativeTag?: unknown;
   __internalInstanceHandle?: unknown;
   getNativeRef?: () => unknown;
+  _cameraRef?: { current?: unknown };
 };
 
 type CameraInputObject = {
@@ -51,10 +57,31 @@ function isCameraRef(value: unknown): value is LegacyCameraOrCameraViewRef {
   if ("_nativeTag" in obj) return true;
   if ("__internalInstanceHandle" in obj) return true;
   if (typeof obj.getNativeRef === "function") return true;
+  // Modern (SDK 51+) `CameraView` class instance. Its native ref lives at
+  // `_cameraRef.current` and gets unwrapped in `unwrapNativeCameraRef`.
+  if (typeof CameraView === "function" && value instanceof CameraView) return true;
   // Back-compat: legacy `Camera` class instance. The guard handles SDKs
   // where the export is missing entirely (read off the namespace above).
   if (typeof LegacyCamera === "function" && value instanceof LegacyCamera) return true;
   return false;
+}
+
+/**
+ * `CameraView` (SDK 51+) is a React class wrapper, not a native handle. The
+ * real ref lives at `instance._cameraRef.current` (see expo-camera's
+ * `CameraView.js`, which declares `_cameraRef = createRef()` and renders
+ * `<ExpoCamera ... ref={this._cameraRef}>`). Unwrap so both the GL bridge
+ * call AND the `inputHash` WeakMap key on the same identity — otherwise
+ * dispose / cache invariants get desynced.
+ */
+function unwrapNativeCameraRef(input: LegacyCameraOrCameraViewRef): LegacyCameraOrCameraViewRef {
+  if (typeof CameraView === "function" && input instanceof CameraView) {
+    const inner = input._cameraRef?.current;
+    if (inner && typeof inner === "object") {
+      return inner as LegacyCameraOrCameraViewRef;
+    }
+  }
+  return input;
 }
 
 /** Duck-type check: does `value` look like the `{ camera, width, height }` wrapper? */
@@ -93,9 +120,16 @@ export default class ExpoCameraTextureLoader extends WebGLTextureLoaderAsyncHash
     this.objIds.delete(texture);
   }
 
-  /** Unwrap a `CameraInput` to the underlying ref. */
+  /**
+   * Unwrap a `CameraInput` to the underlying native ref. Strips the
+   * `{ camera, width, height }` wrapper, then unwraps `CameraView` to its
+   * inner `_cameraRef.current`. Used by both `inputHash` (so the WeakMap
+   * keys on the native ref) and `loadNoCache` (so the GL bridge gets a
+   * native handle, not the React wrapper).
+   */
   private unwrap(input: CameraInput): LegacyCameraOrCameraViewRef {
-    return isCameraInputObject(input) ? input.camera : input;
+    const ref = isCameraInputObject(input) ? input.camera : input;
+    return unwrapNativeCameraRef(ref);
   }
 
   override inputHash(input: CameraInput): number {

--- a/packages/webgltexture-loader-expo/src/DeprecatedExpoGLObjectTextureLoader.ts
+++ b/packages/webgltexture-loader-expo/src/DeprecatedExpoGLObjectTextureLoader.ts
@@ -17,8 +17,14 @@ export default class ExpoGLObjectTextureLoader extends WebGLTextureLoaderAsyncHa
   override canLoad(input: unknown): boolean {
     if (!available && !warned) {
       warned = true;
-      console.log(
-        "webgltexture-loader-expo: ExponentGLObjectManager.createObjectAsync is not available. Make sure to use the correct version of Expo",
+      // This is a legacy fallback loader. It only activates on Expo
+      // SDKs that still expose `ExponentGLObjectManager.createObjectAsync`;
+      // modern SDKs (51+) have removed it. Demote to debug so it doesn't
+      // misleadingly imply the user is on the wrong Expo version.
+      console.debug(
+        "webgltexture-loader-expo: ExponentGLObjectManager.createObjectAsync " +
+          "is not available on this Expo SDK; the deprecated GLObject loader " +
+          "will not be used. This is expected on Expo SDK 51+.",
       );
     }
     return available && typeof input === "object" && input !== null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5675,27 +5675,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webgltexture-loader-dom-canvas@npm:^2.0.0, webgltexture-loader-dom-canvas@workspace:packages/webgltexture-loader-dom-canvas":
+"webgltexture-loader-dom-canvas@npm:^2.1.0-alpha.0, webgltexture-loader-dom-canvas@workspace:packages/webgltexture-loader-dom-canvas":
   version: 0.0.0-use.local
   resolution: "webgltexture-loader-dom-canvas@workspace:packages/webgltexture-loader-dom-canvas"
   dependencies:
-    webgltexture-loader: "npm:^2.0.0"
+    webgltexture-loader: "npm:^2.1.0-alpha.0"
   languageName: unknown
   linkType: soft
 
-"webgltexture-loader-dom-image-url@npm:^2.0.0, webgltexture-loader-dom-image-url@workspace:packages/webgltexture-loader-dom-image-url":
+"webgltexture-loader-dom-image-url@npm:^2.1.0-alpha.0, webgltexture-loader-dom-image-url@workspace:packages/webgltexture-loader-dom-image-url":
   version: 0.0.0-use.local
   resolution: "webgltexture-loader-dom-image-url@workspace:packages/webgltexture-loader-dom-image-url"
   dependencies:
-    webgltexture-loader: "npm:^2.0.0"
+    webgltexture-loader: "npm:^2.1.0-alpha.0"
   languageName: unknown
   linkType: soft
 
-"webgltexture-loader-dom-video@npm:^2.0.0, webgltexture-loader-dom-video@workspace:packages/webgltexture-loader-dom-video":
+"webgltexture-loader-dom-video@npm:^2.1.0-alpha.0, webgltexture-loader-dom-video@workspace:packages/webgltexture-loader-dom-video":
   version: 0.0.0-use.local
   resolution: "webgltexture-loader-dom-video@workspace:packages/webgltexture-loader-dom-video"
   dependencies:
-    webgltexture-loader: "npm:^2.0.0"
+    webgltexture-loader: "npm:^2.1.0-alpha.0"
   languageName: unknown
   linkType: soft
 
@@ -5703,9 +5703,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "webgltexture-loader-dom@workspace:packages/webgltexture-loader-dom"
   dependencies:
-    webgltexture-loader-dom-canvas: "npm:^2.0.0"
-    webgltexture-loader-dom-image-url: "npm:^2.0.0"
-    webgltexture-loader-dom-video: "npm:^2.0.0"
+    webgltexture-loader-dom-canvas: "npm:^2.1.0-alpha.0"
+    webgltexture-loader-dom-image-url: "npm:^2.1.0-alpha.0"
+    webgltexture-loader-dom-video: "npm:^2.1.0-alpha.0"
   languageName: unknown
   linkType: soft
 
@@ -5713,7 +5713,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "webgltexture-loader-expo-camera@workspace:packages/webgltexture-loader-expo-camera"
   dependencies:
-    webgltexture-loader: "npm:^2.0.0"
+    webgltexture-loader: "npm:^2.1.0-alpha.0"
   peerDependencies:
     expo-camera: "*"
     expo-modules-core: "*"
@@ -5724,7 +5724,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "webgltexture-loader-expo@workspace:packages/webgltexture-loader-expo"
   dependencies:
-    webgltexture-loader: "npm:^2.0.0"
+    webgltexture-loader: "npm:^2.1.0-alpha.0"
   peerDependencies:
     expo-asset: "*"
     expo-modules-core: "*"
@@ -5759,23 +5759,23 @@ __metadata:
     ndarray: "npm:^1.0.19"
     ndarray-ops: "npm:^1.2.2"
     typedarray-pool: "npm:^1.2.0"
-    webgltexture-loader: "npm:^2.0.0"
+    webgltexture-loader: "npm:^2.1.0-alpha.0"
   languageName: unknown
   linkType: soft
 
-"webgltexture-loader-react-native-config@npm:^2.0.0, webgltexture-loader-react-native-config@workspace:packages/webgltexture-loader-react-native-config":
+"webgltexture-loader-react-native-config@npm:^2.1.0-alpha.0, webgltexture-loader-react-native-config@workspace:packages/webgltexture-loader-react-native-config":
   version: 0.0.0-use.local
   resolution: "webgltexture-loader-react-native-config@workspace:packages/webgltexture-loader-react-native-config"
   dependencies:
-    webgltexture-loader: "npm:^2.0.0"
+    webgltexture-loader: "npm:^2.1.0-alpha.0"
   languageName: unknown
   linkType: soft
 
-"webgltexture-loader-react-native-imagesource@npm:^2.0.0, webgltexture-loader-react-native-imagesource@workspace:packages/webgltexture-loader-react-native-imagesource":
+"webgltexture-loader-react-native-imagesource@npm:^2.1.0-alpha.0, webgltexture-loader-react-native-imagesource@workspace:packages/webgltexture-loader-react-native-imagesource":
   version: 0.0.0-use.local
   resolution: "webgltexture-loader-react-native-imagesource@workspace:packages/webgltexture-loader-react-native-imagesource"
   dependencies:
-    webgltexture-loader: "npm:^2.0.0"
+    webgltexture-loader: "npm:^2.1.0-alpha.0"
   languageName: unknown
   linkType: soft
 
@@ -5783,12 +5783,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "webgltexture-loader-react-native@workspace:packages/webgltexture-loader-react-native"
   dependencies:
-    webgltexture-loader-react-native-config: "npm:^2.0.0"
-    webgltexture-loader-react-native-imagesource: "npm:^2.0.0"
+    webgltexture-loader-react-native-config: "npm:^2.1.0-alpha.0"
+    webgltexture-loader-react-native-imagesource: "npm:^2.1.0-alpha.0"
   languageName: unknown
   linkType: soft
 
-"webgltexture-loader@npm:^2.0.0, webgltexture-loader@workspace:*, webgltexture-loader@workspace:packages/webgltexture-loader":
+"webgltexture-loader@npm:^2.1.0-alpha.0, webgltexture-loader@workspace:*, webgltexture-loader@workspace:packages/webgltexture-loader":
   version: 0.0.0-use.local
   resolution: "webgltexture-loader@workspace:packages/webgltexture-loader"
   languageName: unknown


### PR DESCRIPTION
## Summary

- Fix a real-world bug reported by a user testing `webgltexture-loader-expo-camera@2.1.0-alpha.0` against Expo SDK 54 (`expo-camera@~17.0.10`): passing a `CameraView` ref to gl-react produced `WARN ... no loader found for value { _cameraRef: ... }` and the camera loader was never invoked.
- Root cause: the modern `CameraView` class instance has none of the four duck-typed markers `isCameraRef` looks for (`_nativeTag` / `__internalInstanceHandle` / `getNativeRef` / `instanceof LegacyCamera`). The legacy `instanceof Camera` fallback is dead because `Camera` is no longer exported on SDK 54.
- Add a fifth `instanceof CameraView` branch in `canLoad`, gated by `typeof CameraView === "function"` so SDKs that don't export it no-op cleanly. Read the class off the namespace import (same pattern as `LegacyCamera`).
- Unwrap to `instance._cameraRef.current` before calling Expo's GL bridge AND inside `inputHash`. Threading the unwrap through `inputHash` is load-bearing: the WeakMap-based hash counter must key on the eventual native ref, not the React wrapper, or dispose/cache invariants desync.
- Bonus: reword and demote the misleading "Make sure to use the correct version of Expo" log in `DeprecatedExpoGLObjectTextureLoader` — it falsely implied the user was on the wrong Expo version.

## Test plan

- [x] `corepack yarn build` passes
- [x] `corepack yarn test` passes (56 tests, +3 from this PR: `canLoad` accepts a `CameraView` instance, `inputHash` is idempotent across the wrapper, and `inputHash(wrapper)` matches `inputHash(wrapper._cameraRef.current)`)
- [x] `corepack yarn lint` passes (oxlint, 0 warnings)
- [x] `corepack yarn format` passes (oxfmt --check)
- [x] `corepack yarn typecheck` passes
- [x] Changeset added (`patch` for `webgltexture-loader-expo-camera` + `webgltexture-loader-expo`; in pre-mode `alpha` so this becomes `2.1.0-alpha.1`)
- [ ] Smoke-test on a real Expo SDK 54 + `gl-react` consumer (cannot be exercised in CI; package's runtime depends on Expo's GLView which doesn't run in browsers or headless-gl)

🤖 Generated with [Claude Code](https://claude.com/claude-code)